### PR TITLE
Various errata

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -285,7 +285,7 @@
     <li>N-Quads documents
     <li>N-Quads parsers
   </ul>
-  <p>A conforming <strong>N-Quads document</strong> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>,
+  <p>A conforming <strong>N-Quads document</strong> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#n-quads-grammar" class="sectionRef"></a>,
     starting with the <a href="#grammar-production-nquadsDoc"><code>nquadsDoc</code> production</a>.
     An N-Quads document serializes an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>.</p>
 
@@ -334,7 +334,7 @@
     <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
 
     <p>A blank line, consisting of only white space and/or a comment,
-      may appear wherever a <code><a href="#grammar-production-triple">triple</a></code> production is allowed,
+      may appear wherever a <code><a href="#grammar-production-statement">statement</a></code> production is allowed,
       and are treated as white space.</p>
 
     <p class="note">As with, N-Triples [[RDF12-N-TRIPLES]],

--- a/spec/index.html
+++ b/spec/index.html
@@ -466,7 +466,7 @@
     <li>Better align the use of white space and comments with [[RDF12-TURTLE]].</li>
     <li>Removed language about white space use between terminals that would otherwise
       be (mis-)recognized, is this can't happen in N-Triples.</li>
-    <li>Clarify the use of blank lines, including those composed of whitespace
+    <li>Clarify the use of blank lines, including those composed of white space
       and/or comments.
       Comments can appear at the end of a triple before the newline as
       was already evident from <a href="#ex-comments"></a>.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -87,7 +87,7 @@
     and an optional <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
     identifying a <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
     associated with the triple within an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
-    also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad"></a>.
+    also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>' and a new line (optional at the end of a document).</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>RDF 1.2 N-Quads</title>
   <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
@@ -54,15 +54,15 @@
 <body>
 
 <section id='abstract'>
-  <p>N-Quads is a line-based, plain text format for encoding an RDF dataset.</p>
+  <p>N-Quads is a line-based, plain text format for encoding an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>.</p>
 </section>
 
 <section id='sotd'>
   <p>This document is part of the RDF 1.2 document suite.
-  The N-Quads format is a line-based RDF syntax with a similar flavor as N-Triples
-  [[RDF12-N-TRIPLES]]. N-Quads is a syntactic superset of N-Triples. 
+  The N-Quads format is a line-based RDF syntax,
+  which is an extension of N-Triples [[RDF12-N-TRIPLES]].
   The main distinction is that N-Quads allows the encoding of multiple graphs
-  in a single document .</p>
+  in a single document representing an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF Dataset</a>.</p>
 
   <section id="related" data-include="./common/related.html"></section>
 </section>
@@ -77,8 +77,17 @@
     [[!RDF12-CONCEPTS]].
   </p>
 
-  <p>N-quads statements are a sequence of RDF terms representing the subject, predicate, object and graph label
-    of an RDF Triple and the graph it is part of in a dataset.
+  <p>As with N-Triples, an N-Quads document contains no parsing directives.</p>
+
+  <p>N-Quads statements are a sequence of RDF terms representing the
+    <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
+    <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>, and
+    <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>
+    of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF Triple</a>
+    and an optional <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
+    identifying a <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
+    associated with the triple within an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
+    also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad"></a>.
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>' and a new line (optional at the end of a document).</p>
 
@@ -91,15 +100,33 @@
     -->
   </pre>
 
+  <p>The <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a> represented by an N-Quads document contains
+    exactly each <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a> matching the N-Quads
+    <a href="#grammar-production-statement"><code>statement</code></a> production.
+  </p>
+
 </section>
 
 <section>
   <h2>N-Quads Language</h2>
   <section id="simple-triples">
     <h3>Simple Statements</h3>
-    <p>The simplest statement is a sequence of (subject, predicate, object) terms
-      forming an RDF triple and an optional blank node label or IRI labeling what graph
-      in a dataset the triple belongs to,
+
+    <p>A simple statement extends the
+      <a data-cite="RDF12-N-TRIPLES#simple-triples">definition of simple triple</a> in [[RDF12-N-TRIPLES]]
+      with an optional <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>.</p>
+
+    <p>The simplest statement is a sequence of
+      (<a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
+      <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>,
+      <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>) terms
+      forming an <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>
+      and an optional
+      <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
+      (a <a data-cite="RDF12-CONCEPTS#dfn-blank-node-label">blank node label</a>
+      or <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>) labeling what
+      <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
+      in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to,
       all are separated by whitespace and terminated by '<code>.</code>' after each statement.</p>
 
     <pre class="example nquads" data-transform="updateExample">
@@ -108,15 +135,16 @@
       -->
     </pre>
 
-    <p>The graph label IRI can be omitted, in which case the triples are considered
-      part of the default graph of the RDF dataset.<p>
+    <p>The <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> can be omitted, in which case the triples are considered
+      part of the
+      <a data-cite="RDF12-CONCEPTS#dfn-default-graph">default graph</a> of the <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>.<p>
   </section>
 
   <section id="sec-iri">
     <h3>IRIs</h3>
 
     <p>
-      <a data-cite="RDF12-CONCEPTS#iri">IRIs</a> may be written only as absolute IRIs.
+      As in N-Triples, <a data-cite="RDF12-CONCEPTS#iri">IRIs</a> may be written only as absolute IRIs.
       IRIs are enclosed in '&lt;' and '&gt;' and may contain numeric escape sequences (described below).
       For example <code>&lt;http://example.org/#green-goblin&gt;</code>.
     </p>
@@ -125,7 +153,8 @@
   <section id="sec-literals">
     <h3>RDF Literals</h3>
 
-    <p><a data-cite="RDF12-CONCEPTS#literal">Literals</a> are used to identify values such as strings, numbers, dates.</p>
+    <p>As in N-Triples,
+      <a data-cite="RDF12-CONCEPTS#literal">literals</a> are used to identify values such as strings, numbers, dates.</p>
 
     <p>
       Literals (Grammar production <a href="#grammar-production-literal">Literal</a>)
@@ -135,7 +164,7 @@
       a sequence of permitted characters or numeric escape sequence or string escape sequence,
       and a final delimiter.
       Literals may not contain the characters <code>"</code>,
-      code title="LINE FEED"><sub>LF</sub></code>,
+      <code title="LINE FEED"><sub>LF</sub></code>,
       or <code title="CARRIAGE RETURN"><sub>CR</sub></code>.
       In addition '<code>\</code>' (<span class="codepoint">U+005C</span>)
       may not appear in any quoted literal except as part of an escape sequence.
@@ -152,7 +181,8 @@
   <section id="BNodes">
     <h3>RDF Blank Nodes</h3>
     <p>
-      <a data-cite="RDF12-CONCEPTS#blank-node">RDF blank nodes</a> in N-Quads are expressed as <code>_:</code>
+      As in N-Triples,
+      <a data-cite="RDF12-CONCEPTS#blank-node">RDF blank nodes</a> are expressed as <code>_:</code>
       followed by a blank node label which is a series of name characters.
       The characters in the label are built upon <a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a>,
       liberalized as follows:
@@ -176,6 +206,10 @@
       _:bob <http://xmlns.com/foaf/0.1/knows> _:alice <http://example.org/graphs/james> .
       -->
     </pre>
+  <p class="issue" data-number="2">
+    Note open <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_30">erratum</a> on aligning the definition and production
+    for blank node lables with Turtle.
+  </p>
   </section>
 </section>
 
@@ -185,11 +219,16 @@
     <li>N-Quads documents
     <li>N-Quads parsers
   </ul>
-  <p>A conforming <strong>N-Quads document</strong> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>, starting with the <a href="#grammar-production-nquadsDoc"><code>nquadsDoc</code> production</a>. An N-Quad document serializes an RDF dataset.</p>
+  <p>A conforming <strong>N-Quads document</strong> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>,
+    starting with the <a href="#grammar-production-nquadsDoc"><code>nquadsDoc</code> production</a>.
+    An N-Quads document serializes an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>.</p>
 
   <p class="note">N-Quads documents do not provide a way of serializing empty graphs that may be part of an RDF dataset.</p>
 
-  <p>A conforming <strong>N-Quads parser</strong> is a system capable of reading N-Quads documents on behalf of an application. It makes the serialized RDF graph, as defined in <a href="#sec-parsing" class="sectionRef"></a>, available to the application, usually through some form of API.</p>
+  <p>A conforming <strong>N-Quads parser</strong> is a system capable of reading N-Quads documents on behalf of an application.
+    It makes the serialized <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
+    as defined in <a href="#sec-parsing" class="sectionRef"></a>,
+    available to the application, usually through some form of API.</p>
 
   <p>The IRI that identifies the N-Quads language is: <code>http://www.w3.org/ns/formats/N-Quads</code></p>
 
@@ -216,7 +255,7 @@
 <section id="sec-grammar">
   <h3>Grammar</h3>
 
-  <p>An N-Quads document is a Unicode[[!UNICODE]] character string encoded in UTF-8.
+  <p>An N-Quads document is a Unicode [[!UNICODE]] character string encoded in UTF-8.
     Unicode code points only in the range U+0 to U+10FFFF inclusive are allowed.</p>
 
   <p>White space (tab <code>U+0009</code> or space <code>U+0020</code>) is used to separate two terminals which would otherwise be (mis-)recognized as one terminal. White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
@@ -264,7 +303,17 @@
 
   <section id="rdf-dataset-construction">
     <h3>RDF Dataset Construction</h3>
-    <p>An N-Quads document defines an RDF dataset composed of RDF graphs composed of a set of RDF triples. The  <code><a href="#grammar-production-statement">statement</a></code> production produces a triple defined by the terms constructed for <code><a href="#grammar-production-subject">subject</a></code>, <code><a href="#grammar-production-predicate">predicate</a></code> and <code><a href="#grammar-production-object">object</a></code>. This RDF triple is added to the graph labeled by the production <code><a href="#grammar-production-graphLabel">graphLabel</a></code>, if no <code>graphLabel</code> is present the triple is added to the RDF datasets default graph.</p>
+    <p>An N-Quads document defines an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>
+      composed of <a href="RDF12-CONCEPTS#dfn-rdf-graph">RDF graphs</a> composed of a set of
+      <a href="RDF12-CONCEPTS#dfn-rdf-triple">RDF triples</a>.
+      The  <code><a href="#grammar-production-statement">statement</a></code> production produces a
+      triple defined by the terms constructed for
+      <code><a href="#grammar-production-subject">subject</a></code>,
+      <code><a href="#grammar-production-predicate">predicate</a></code>, and
+      <code><a href="#grammar-production-object">object</a></code>.
+      This RDF triple is added to the <a data-cite="RDF12-CONCEPTS#dfn-named-graph">graph</a> labeled by
+      the production <code><a href="#grammar-production-graphLabel">graphLabel</a></code>,
+      if no <code>graphLabel</code> is present the triple is added to the RDF dataset's default graph.</p>
   </section>
 </section>
 
@@ -317,7 +366,8 @@
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
-    
+    <li>N-Quads is now described as a syntactic superset of [[RDF12-N-TRIPLES]].</li>
+    <li>Add <a href="#canonical-quads" class="sectionRef"></a> to define the canonical form of N-Quads.</li>
   </ul>
 </section>
 
@@ -425,5 +475,8 @@
 </section>
 
 <section id="index"></section>
+<section class="appendix" id="issue-summary">
+  <!-- A list of issues will magically appear here -->
+</section>
 </body>
 </html>

--- a/spec/index.html
+++ b/spec/index.html
@@ -94,7 +94,7 @@
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>'
     (optionaly proceded by white space and/or a comment),
-    and a new line.</p>
+    and a new line (optional at the end of a document).</p>
 
   <pre id="ex-comments" class="example nquads" data-transform="updateExample"
        title="Use of comments in N-Quads">
@@ -476,7 +476,6 @@
       for <a href="#sec-grammar-ws">White space</a> and
       <a href="#sec-grammar-comments">Comments</a>,
       better mirroring [[RDF12-TURTLE]].</li>
-    <li>A valid N-Quads document must end with an EOL <code>U+000A</code>.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -94,7 +94,7 @@
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>'
     (optionaly proceded by white space and/or a comment),
-    and a new line (optional at the end of a document).</p>
+    and a new line.</p>
 
   <pre id="ex-comments" class="example nquads" data-transform="updateExample"
        title="Use of comments in N-Quads">
@@ -476,6 +476,7 @@
       for <a href="#sec-grammar-ws">White space</a> and
       <a href="#sec-grammar-comments">Comments</a>,
       better mirroring [[RDF12-TURTLE]].</li>
+    <li>A valid N-Quads document must end with an EOL <code>U+000A</code>.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -213,6 +213,39 @@
   </section>
 </section>
 
+<section id="canonical-quads">
+  <h2>A Canonical form of N-Quads</h2>
+  <p>This section defined a canonical form of N-Quads which has
+    less variability in layout. The grammar for the language is the
+    same.  Implementers are encouraged to produce this form.</p>
+  <p>Canonical N-Quads has the following additional constraints on layout:</p>
+  <ul>
+    <li>The whitespace following <code>subject</code>,
+      <code>predicate</code>, 
+      <code>object</code>,
+      and <code>graphLabel</code> if present, MUST be a single space, 
+      (<code>U+0020</code>).  All other locations that allow 
+      whitespace MUST be empty.</li>
+    <li>There MUST be no comments.</li>
+    <li><code>HEX</code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
+    <li>Characters MUST NOT be represented by <code>UCHAR</code>.</li>
+    <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
+      only the characters 
+      <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
+       are encoded using <code>ECHAR</code>.
+      <code>ECHAR</code> MUST NOT be used for characters that are
+      allowed directly in
+      <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>. </li>
+  </ul>
+  <div class="issue" data-number="2">
+    Note open errata:
+    <ul>
+      <li><a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_32">32 – Issues with N-Quads/N-Triples canonicalization</a>.</li>
+      <li><a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_33">33 – Ambiguity of canonical N-Triples</a></li>
+    </ul>
+  </div>
+</section>
+
 <section id="conformance">
   <p>This specification defines conformance criteria for:</p>
   <ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -269,6 +269,8 @@
       <code>ECHAR</code> MUST NOT be used for characters that are
       allowed directly in
       <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>. </li>
+      <li>The token EOL MUST be a single <code>U+000A</code>.</li>
+      <li>The final EOL MUST be provided.</li>
   </ul>
   <div class="issue" data-number="2">
     Note open errata:

--- a/spec/index.html
+++ b/spec/index.html
@@ -89,7 +89,9 @@
     associated with the triple within an <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
     also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
-    This sequence is terminated by a '<code>.</code>' and a new line (optional at the end of a document).</p>
+    This sequence is terminated by a '<code>.</code>'
+    (optionaly proceded by white space),
+    and a new line (optional at the end of a document).</p>
 
   <pre class="example nquads" data-transform="updateExample">
     <!--
@@ -109,6 +111,13 @@
 
 <section>
   <h2>N-Quads Language</h2>
+
+    <p>An N-Quads document is composed of a sequence
+      of <a href="#simple-triples">simple statements</a>,
+      one for each line.
+      Lines consisteng entirely of white space  (spaces <code>U+0020</code> or tabs <code>U+0009</code>)
+      and/or comments are permitted before or after each triple.</p>
+
   <section id="simple-triples">
     <h3>Simple Statements</h3>
 
@@ -127,7 +136,9 @@
       or <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>) labeling what
       <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
       in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to,
-      all are separated by whitespace and terminated by '<code>.</code>' after each statement.</p>
+      all are separated by whitespace and terminated by '<code>.</code>' after each statement.
+      White space MAY occur beteween elements of this sequence.
+      Comments MAY occur after the terminating '<code>.</code>'.</p>
 
     <pre class="example nquads" data-transform="updateExample">
       <!--
@@ -291,7 +302,8 @@
   <p>An N-Quads document is a Unicode [[!UNICODE]] character string encoded in UTF-8.
     Unicode code points only in the range U+0 to U+10FFFF inclusive are allowed.</p>
 
-  <p>White space (tab <code>U+0009</code> or space <code>U+0020</code>) is used to separate two terminals which would otherwise be (mis-)recognized as one terminal. White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
+  <p>White space (tab U+0009 or space U+0020) is allowed but not required between any two terminals.
+    White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
 
   <p>Comments in N-Quads take the form of '<code>#</code>',
     outside an <code>IRIREF</code> or <code>STRING_LITERAL_QUOTE</code>,
@@ -401,6 +413,10 @@
   <ul>
     <li>N-Quads is now described as a syntactic superset of [[RDF12-N-TRIPLES]].</li>
     <li>Add <a href="#canonical-quads" class="sectionRef"></a> to define the canonical form of N-Quads.</li>
+    <li>Clarify the use of white space to separate RDF terms and the trailing `.` in a triple.
+      Lines composed entirely of white space and/or comments are also allowed.</li>
+    <li>Removed language about white space use between terminals that would otherwise
+      be (mis-)recognized, is this can't happen in N-Triples.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -71,7 +71,10 @@
   <h2>Introduction</h2>
 
   <p>
-    This document defines N-Quads, an easy to parse, line-based,
+    This document defines N-Quads, a concrete syntax for 
+    RDF [[RDF12-CONCEPTS]],
+    and an extension of N-Triples [[RDF12-N-TRIPLES]].
+    N-Quads is an easy to parse, line-based,
     concrete syntax for
     <a data-cite="RDF12-CONCEPTS#section-dataset">RDF Datasets</a>
     [[!RDF12-CONCEPTS]].
@@ -90,10 +93,11 @@
     also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>'
-    (optionaly proceded by white space),
+    (optionaly proceded by white space and/or a comment),
     and a new line (optional at the end of a document).</p>
 
-  <pre class="example nquads" data-transform="updateExample">
+  <pre id="ex-comments" class="example nquads" data-transform="updateExample"
+       title="Use of comments in N-Quads">
     <!--
     <http://one.example/subject1> <http://one.example/predicate1> <http://one.example/object1> <http://example.org/graph3> . # comments here
     # or on a line by themselves
@@ -109,14 +113,21 @@
 
 </section>
 
-<section>
+<section id="sec-n-quads-language" class="informative">
   <h2>N-Quads Language</h2>
 
-    <p>An N-Quads document is composed of a sequence
-      of <a href="#simple-triples">simple statements</a>,
-      one for each line.
-      Lines consisteng entirely of white space  (spaces <code>U+0020</code> or tabs <code>U+0009</code>)
-      and/or comments are permitted before or after each triple.</p>
+  <p>An N-Quads document allows writing down an
+    <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>
+    in a textual form.
+    An RDF dataset is made up of <a href="#simple-triples">simple statements</a>
+    consisting of a
+    <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
+    <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>,
+    <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>, an optional
+    <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
+    and optional blank lines.
+    Comments may be given after a '<code>#</code>' that is not part of
+    another lexical token and continue to the end of the line.</p>
 
   <section id="simple-triples">
     <h3>Simple Statements</h3>
@@ -135,20 +146,23 @@
       (a <a data-cite="RDF12-CONCEPTS#dfn-blank-node-label">blank node label</a>
       or <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>) labeling what
       <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
-      in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to,
-      all are separated by whitespace and terminated by '<code>.</code>' after each statement.
-      White space MAY occur beteween elements of this sequence.
-      Comments MAY occur after the terminating '<code>.</code>'.</p>
+      in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to.
+      White space (spaces <code>U+0020</code> or tabs <code>U+0009</code>) may surround terms,
+      except where significant as noted in the <a href="#n-quads-grammar">grammar</a>.</p>
 
-    <pre class="example nquads" data-transform="updateExample">
-      <!--
-      <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> <http://example.org/graphs/spiderman> .</script>
-      -->
-    </pre>
+    <p>Comments are treated as white space, and may be given after a '<code>#</code>' that is not part of
+      another lexical token and continue to the end of the line.</p>
 
     <p>The <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> can be omitted, in which case the triples are considered
       part of the
       <a data-cite="RDF12-CONCEPTS#dfn-default-graph">default graph</a> of the <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>.<p>
+
+    <pre id="ex-simple-statement" class="example nquads" data-transform="updateExample"
+         title="Simple Statement">
+      <!--
+      <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> <http://example.org/graphs/spiderman> .</script>
+      -->
+    </pre>
   </section>
 
   <section id="sec-iri">
@@ -167,25 +181,30 @@
     <p>As in N-Triples,
       <a data-cite="RDF12-CONCEPTS#literal">literals</a> are used to identify values such as strings, numbers, dates.</p>
 
-    <p>
-      Literals (Grammar production <a href="#grammar-production-literal">Literal</a>)
-      have a lexical form followed by a language tag, a datatype IRI, or neither.
-      The representation of the lexical form consists of an
-      initial delimiter <code>"</code> (<span class="codepoint">U+0022</span>),
+    <p>The representation of the lexical form consists of an
+      initial delimiter <code>&quot;</code> (<span class="codepoint">U+0022</span>),
       a sequence of permitted characters or numeric escape sequence or string escape sequence,
-      and a final delimiter.
-      Literals may not contain the characters <code>"</code>,
-      <code title="LINE FEED"><sub>LF</sub></code>,
-      or <code title="CARRIAGE RETURN"><sub>CR</sub></code>.
+      and a final delimiter.</p>
+
+    <p>Literals may not contain the characters <code>&quot;</code>,
+      <code title="LINE FEED"><sub>LF</sub></code> (<span class="codepoint">U+000A</span>), or
+      <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<span class="codepoint">U+000D</span>)
+      except in their escaped forms.
       In addition '<code>\</code>' (<span class="codepoint">U+005C</span>)
-      may not appear in any quoted literal except as part of an escape sequence.
-      The corresponding <a data-cite="RDF12-CONCEPTS#lexical-form">RDF lexical form</a> is
-      the characters between the delimiters, after processing any escape sequences.
-      If present, the <a data-cite="RDF12-CONCEPTS#language-tag">language tag</a> is preceded by a
-      '<code>@</code>' (<span class="codepoint">U+0040</span>).
+      may not appear in any quoted literal except as part of an escape sequence
+      and a <code>"</code> (<span class="codepoint">U+0022</span>) character
+      can only be included in a quote literal using an escape sequence.
+      </p>
+
+    <p>The corresponding <a data-cite="RDF12-CONCEPTS#lexical-form">RDF lexical form</a>
+      is the characters between the delimiters, after processing any escape sequences.
+      If present, the <a data-cite="RDF12-CONCEPTS#language-tag">language tag</a>
+      is preceded by a '<code>@</code>' (<span class="codepoint">U+0040</span>).
       If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#datatype-iri">datatype IRI</a>,
       preceded by '<code>^^</code>' (<span class="codepoint">U+005E</span> <span class="codepoint">U+005E</span>).
-      If there is no datatype IRI and no language tag, the datatype is <code>xsd:string</code>.
+      If there is no datatype IRI and no language tag
+      it is a <a data-cite="RDF12-CONCEPTS#simple-literal">simple literal</a>
+      and the datatype is <code>http://www.w3.org/2001/XMLSchema#string</code>.
     </p>
   </section>
 
@@ -199,44 +218,47 @@
       liberalized as follows:
     </p>
     <ul>
-      <li>The characters <code>_</code> and digits may appear anywhere in a blank node label.</li>
+      <li>The characters <code>_</code> and <code>[0-9]</code> may appear anywhere in a blank node label.</li>
       <li>The character <code>.</code> may appear anywhere except the first or last character.</li>
-      <li>The characters <code>-</code>, <code>U+00B7</code>,
-        <code>U+0300</code> to <code>U+036F</code>
-        and <code>U+203F</code> to <code>U+2040</code>
-        are permitted anywhere except the first character.</li>
+      <li>The characters <code>-</code>, <code>U+00B7</code>, <code>U+0300</code> to <code>U+036F</code> and <code>U+203F</code> to <code>U+2040</code> are permitted anywhere except the first character.</li>
     </ul>
     <p>
       A fresh RDF blank node is allocated for each unique blank node label in a document.
       Repeated use of the same blank node label identifies the same RDF blank node.
     </p>
 
-    <pre class="example nquads" data-transform="updateExample">
+    <pre id="ex-bnodes" class="example ntriples" data-transform="updateExample"
+         title="Blank nodes in N-Quads">
       <!--
-      _:alice <http://xmlns.com/foaf/0.1/knows> _:bob <http://example.org/graphs/john> .
-      _:bob <http://xmlns.com/foaf/0.1/knows> _:alice <http://example.org/graphs/james> .
+      _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
+      _:bob <http://xmlns.com/foaf/0.1/knows> _:alice .
       -->
     </pre>
-  <p class="issue" data-number="2">
-    Note open <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_30">erratum</a> on aligning the definition and production
-    for blank node lables with Turtle.
-  </p>
+    <p class="issue" data-number="2">
+      Note open <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_30">erratum</a> on aligning the definition and production
+      for blank node lables with Turtle.
+    </p>
   </section>
 </section>
 
 <section id="canonical-quads">
   <h2>A Canonical form of N-Quads</h2>
-  <p>This section defined a canonical form of N-Quads which has
-    less variability in layout. The grammar for the language is the
-    same.  Implementers are encouraged to produce this form.</p>
+
+  <p>This section defines a canonical form of N-Quads which has
+    less variability in layout.
+    The grammar for the language is the same.</p>
+
+  <p class="note">Even when not explicitly serializing
+    canonical N-Quads, implementers are encouraged to produce this form.</p>
+
   <p>Canonical N-Quads has the following additional constraints on layout:</p>
   <ul>
-    <li>The whitespace following <code>subject</code>,
+    <li>The white space following <code>subject</code>,
       <code>predicate</code>, 
       <code>object</code>,
       and <code>graphLabel</code> if present, MUST be a single space, 
       (<code>U+0020</code>).  All other locations that allow 
-      whitespace MUST be empty.</li>
+      white space MUST be empty.</li>
     <li>There MUST be no comments.</li>
     <li><code>HEX</code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
     <li>Characters MUST NOT be represented by <code>UCHAR</code>.</li>
@@ -269,7 +291,8 @@
 
   <p class="note">N-Quads documents do not provide a way of serializing empty graphs that may be part of an RDF dataset.</p>
 
-  <p>A conforming <strong>N-Quads parser</strong> is a system capable of reading N-Quads documents on behalf of an application.
+  <p>A conforming <dfn class="lint-ignore">>N-Quads parser</dfn> is a system capable of
+    reading N-Quads documents on behalf of an application.
     It makes the serialized <a href="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
     as defined in <a href="#sec-parsing" class="sectionRef"></a>,
     available to the application, usually through some form of API.</p>
@@ -280,9 +303,9 @@
     <h2>Media Type and Content Encoding</h2>
 
     <p>The media type of N-Quads is <code>application/n-quads</code>.
-    The content encoding of N-Quads is always UTF-8.
-    See <a href="#sec-mediaReg">N-Quads Media Type</a> for the media type
-    registration form.
+      The content encoding of N-Quads is always UTF-8.
+      See <a href="#sec-mediaReg">N-Quads Media Type</a> for the media type
+      registration form.
     </p>
 
     <section id="sec-other-media-types">
@@ -296,29 +319,54 @@
   </section>
 </section>
 
-<section id="sec-grammar">
-  <h3>Grammar</h3>
+<section id="n-quads-grammar"><span id="sec-grammar"></span>
+  <h3>N-Quads Grammar</h3>
 
-  <p>An N-Quads document is a Unicode [[!UNICODE]] character string encoded in UTF-8.
-    Unicode code points only in the range U+0 to U+10FFFF inclusive are allowed.</p>
+  <p>An N-Quads document is a Unicode [[!UNICODE]] character string encoded in UTF-8.</p>
 
-  <p>White space (tab U+0009 or space U+0020) is allowed but not required between any two terminals.
-    White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
+  <section id="sec-grammar-ws">
+    <h3>White Space</h3>
 
-  <p>Comments in N-Quads take the form of '<code>#</code>',
-    outside an <code>IRIREF</code> or <code>STRING_LITERAL_QUOTE</code>,
-    and continue to the end of line (<code>EOL</code>) or end of file
-    if there is no end of line after the comment marker.
-    Comments are treated as white space.</p>
+    <p>White space (tab U+0009 or space U+0020) is allowed outside of terminals.
+      Rule names below in capitals indicate where white space is significant.
+</p>
 
-  <p>The <abbr title="Extended Backus–Naur Form">EBNF</abbr> used here is defined in XML 1.0
-    [[!EBNF-NOTATION]].</p>
+    <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
 
-  <p>Escape sequence rules are the same as Turtle [[RDF12-TURTLE]].
-    However, as only the <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a> production
-    is allowed new lines in literals MUST be escaped.</p>
+    <p>A blank line, consisting of only white space and/or a comment,
+      may appear wherever a <code><a href="#grammar-production-triple">triple</a></code> production is allowed,
+      and are treated as white space.</p>
 
-  <div data-include="nquads-bnf.html"></div>
+    <p class="note">As with, N-Triples [[RDF12-N-TRIPLES]],
+      N-Quads allows only horizontal white space  (tab U+0009 or space U+0020).</p>
+  </section>
+
+  <section id="sec-grammar-comments">
+    <h3>Comments</h3>
+
+    <p>Comments in N-Quads start at '<code>#</code>'
+      outside an <a href="#grammar-production-IRIREF">IRIREF</a> or <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
+      and continue to the end of line
+      (marked by characters
+      <code title="CARRIAGE RETURN"><sub>CR</sub></code> (<span class="codepoint">U+000D</span> or
+      <code title="LINE FEED"><sub>LF</sub></code> (<span class="codepoint">U+000A</span>))
+      or end of file if there is no end of line after the comment
+      marker.
+      Comments are treated as white space.</p>
+  </section>
+
+  <section id="sec-grammar-grammar">
+    <h3>Grammar</h3>
+
+    <p>The <abbr title="Extended Backus–Naur Form">EBNF</abbr> used
+      here is defined in XML 1.0 [[EBNF-NOTATION]].</p>
+
+    <p>Escape sequence rules are the same as N-Triples [[RDF12-N-TRIPLES]] and Turtle [[RDF12-TURTLE]].
+      However, as only the <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>
+      production is allowed new lines in literals MUST be escaped.</p>
+
+    <div data-include="nquads-bnf.html"></div>
+  </section>
 </section>
 
 <section id="sec-parsing">
@@ -382,6 +430,8 @@
   <section class="informative">
     <h3>Acknowledgments for RDF 1.2</h3>
 
+    <p>The editors of the RDF 1.2 edition acknowledge valuable contributions from Andy Seabourn.</p>
+
     <p>In addition to the editors, the following people have contributed to this specification:
       <span id="gh-contributors"></span>
     </p>
@@ -411,12 +461,19 @@
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
-    <li>N-Quads is now described as a syntactic superset of [[RDF12-N-TRIPLES]].</li>
+    <li>N-Quads is now described as an extension of N-Triples [[RDF12-N-TRIPLES]].</li>
     <li>Add <a href="#canonical-quads" class="sectionRef"></a> to define the canonical form of N-Quads.</li>
-    <li>Clarify the use of white space to separate RDF terms and the trailing `.` in a triple.
-      Lines composed entirely of white space and/or comments are also allowed.</li>
+    <li>Better align the use of white space and comments with [[RDF12-TURTLE]].</li>
     <li>Removed language about white space use between terminals that would otherwise
       be (mis-)recognized, is this can't happen in N-Triples.</li>
+    <li>Clarify the use of blank lines, including those composed of whitespace
+      and/or comments.
+      Comments can appear at the end of a triple before the newline as
+      was already evident from <a href="#ex-comments"></a>.</li>
+    <li>Create separate subsections of <a href="#n-quads-grammar"></a>
+      for <a href="#sec-grammar-ws">White space</a> and
+      <a href="#sec-grammar-comments">Comments</a>,
+      better mirroring [[RDF12-TURTLE]].</li>
   </ul>
 </section>
 


### PR DESCRIPTION
* Reference terms from RDF Concepts.
* Use *graph name" rather than "graph label" in most places, to align with the term from RDF Concepts.
* Add canonical form of N-Quads.
* Add issue markers for Blank Node representation, and open issues on canonicalization.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/11.html" title="Last updated on Feb 13, 2023, 5:27 PM UTC (bf0616c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/11/22a21df...bf0616c.html" title="Last updated on Feb 13, 2023, 5:27 PM UTC (bf0616c)">Diff</a>