### PR TITLE
Grammar bnode label

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -476,6 +476,8 @@
       for <a href="#sec-grammar-ws">White space</a> and
       <a href="#sec-grammar-comments">Comments</a>,
       better mirroring [[RDF12-TURTLE]].</li>
+    <li>Updated the <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
+      grammar production to be consisten with with Turtle.</li>
   </ul>
 </section>
 

--- a/spec/nquads-bnf.html
+++ b/spec/nquads-bnf.html
@@ -91,12 +91,6 @@
     <td>::=</td>
     <td>[<code class='grammar-chars'>A-Z</code>] <code>| </code> [<code class='grammar-chars'>a-z</code>] <code>| </code> [<code class='grammar-chars'>#x00C0-#x00D6</code>] <code>| </code> [<code class='grammar-chars'>#x00D8-#x00F6</code>] <code>| </code> [<code class='grammar-chars'>#x00F8-#x02FF</code>] <code>| </code> [<code class='grammar-chars'>#x0370-#x037D</code>] <code>| </code> [<code class='grammar-chars'>#x037F-#x1FFF</code>] <code>| </code> [<code class='grammar-chars'>#x200C-#x200D</code>] <code>| </code> [<code class='grammar-chars'>#x2070-#x218F</code>] <code>| </code> [<code class='grammar-chars'>#x2C00-#x2FEF</code>] <code>| </code> [<code class='grammar-chars'>#x3001-#xD7FF</code>] <code>| </code> [<code class='grammar-chars'>#xF900-#xFDCF</code>] <code>| </code> [<code class='grammar-chars'>#xFDF0-#xFFFD</code>] <code>| </code> [<code class='grammar-chars'>#x10000-#xEFFFF</code>]</td>
 </tr>
-            <tr id="grammar-production-PN_CHARS_U" data-grammar-original="[158s] PN_CHARS_U       ::=  PN_CHARS_BASE| &#x27;_&#x27;| &#x27;:&#x27;" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_BASE&#x27;), (&quot;&#x27;&quot;, &#x27;_&#x27;), (&quot;&#x27;&quot;, &#x27;:&#x27;)])" class='grammar-token'>
-    <td>[158s]</td>
-    <td><code>PN_CHARS_U</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> <code>| </code> '<code class='grammar-literal'>_</code>' <code>| </code> '<code class='grammar-literal'>:</code>'</td>
-</tr>
             <tr id="grammar-production-PN_CHARS" data-grammar-original="[160s] PN_CHARS         ::= PN_CHARS_U| &quot;-&quot;| [0-9]| #x00B7| [#x0300-#x036F]| [#x203F-#x2040]" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_U&#x27;), (&quot;&#x27;&quot;, &#x27;-&#x27;), (&#x27;[&#x27;, &#x27;0-9&#x27;), (&#x27;#&#x27;, &#x27;#x00B7&#x27;), (&#x27;[&#x27;, &#x27;#x0300-#x036F&#x27;), (&#x27;[&#x27;, &#x27;#x203F-#x2040&#x27;)])" class='grammar-token'>
     <td>[160s]</td>
     <td><code>PN_CHARS</code></td>
@@ -108,5 +102,11 @@
     <td><code>HEX</code></td>
     <td>::=</td>
     <td>[<code class='grammar-chars'>0-9</code>] <code>| </code> [<code class='grammar-chars'>A-F</code>] <code>| </code> [<code class='grammar-chars'>a-f</code>]</td>
+</tr>
+            <tr id="grammar-production-PN_CHARS_U" data-grammar-original="[164s] PN_CHARS_U       ::=  PN_CHARS_BASE| &#x27;_&#x27;" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_BASE&#x27;), (&quot;&#x27;&quot;, &#x27;_&#x27;), (&quot;&#x27;&quot;, &#x27;:&#x27;)])" class='grammar-token'>
+    <td>[158s]</td>
+    <td><code>PN_CHARS_U</code></td>
+    <td>::=</td>
+    <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> <code>| </code> '<code class='grammar-literal'>_</code>'</td>
 </tr>
 </table>

--- a/spec/nquads-bnf.html
+++ b/spec/nquads-bnf.html
@@ -91,6 +91,12 @@
     <td>::=</td>
     <td>[<code class='grammar-chars'>A-Z</code>] <code>| </code> [<code class='grammar-chars'>a-z</code>] <code>| </code> [<code class='grammar-chars'>#x00C0-#x00D6</code>] <code>| </code> [<code class='grammar-chars'>#x00D8-#x00F6</code>] <code>| </code> [<code class='grammar-chars'>#x00F8-#x02FF</code>] <code>| </code> [<code class='grammar-chars'>#x0370-#x037D</code>] <code>| </code> [<code class='grammar-chars'>#x037F-#x1FFF</code>] <code>| </code> [<code class='grammar-chars'>#x200C-#x200D</code>] <code>| </code> [<code class='grammar-chars'>#x2070-#x218F</code>] <code>| </code> [<code class='grammar-chars'>#x2C00-#x2FEF</code>] <code>| </code> [<code class='grammar-chars'>#x3001-#xD7FF</code>] <code>| </code> [<code class='grammar-chars'>#xF900-#xFDCF</code>] <code>| </code> [<code class='grammar-chars'>#xFDF0-#xFFFD</code>] <code>| </code> [<code class='grammar-chars'>#x10000-#xEFFFF</code>]</td>
 </tr>
+            <tr id="grammar-production-PN_CHARS_U" data-grammar-original="[164s] PN_CHARS_U       ::=  PN_CHARS_BASE| &#x27;_&#x27;" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_BASE&#x27;), (&quot;&#x27;&quot;, &#x27;_&#x27;), (&quot;&#x27;&quot;, &#x27;:&#x27;)])" class='grammar-token'>
+    <td>[158s]</td>
+    <td><code>PN_CHARS_U</code></td>
+    <td>::=</td>
+    <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> <code>| </code> '<code class='grammar-literal'>_</code>'</td>
+</tr>
             <tr id="grammar-production-PN_CHARS" data-grammar-original="[160s] PN_CHARS         ::= PN_CHARS_U| &quot;-&quot;| [0-9]| #x00B7| [#x0300-#x036F]| [#x203F-#x2040]" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_U&#x27;), (&quot;&#x27;&quot;, &#x27;-&#x27;), (&#x27;[&#x27;, &#x27;0-9&#x27;), (&#x27;#&#x27;, &#x27;#x00B7&#x27;), (&#x27;[&#x27;, &#x27;#x0300-#x036F&#x27;), (&#x27;[&#x27;, &#x27;#x203F-#x2040&#x27;)])" class='grammar-token'>
     <td>[160s]</td>
     <td><code>PN_CHARS</code></td>
@@ -102,11 +108,5 @@
     <td><code>HEX</code></td>
     <td>::=</td>
     <td>[<code class='grammar-chars'>0-9</code>] <code>| </code> [<code class='grammar-chars'>A-F</code>] <code>| </code> [<code class='grammar-chars'>a-f</code>]</td>
-</tr>
-            <tr id="grammar-production-PN_CHARS_U" data-grammar-original="[164s] PN_CHARS_U       ::=  PN_CHARS_BASE| &#x27;_&#x27;" data-grammar-expression="(&#x27;|&#x27;, [(&#x27;id&#x27;, &#x27;PN_CHARS_BASE&#x27;), (&quot;&#x27;&quot;, &#x27;_&#x27;), (&quot;&#x27;&quot;, &#x27;:&#x27;)])" class='grammar-token'>
-    <td>[158s]</td>
-    <td><code>PN_CHARS_U</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> <code>| </code> '<code class='grammar-literal'>_</code>'</td>
 </tr>
 </table>

--- a/spec/nquads.bnf
+++ b/spec/nquads.bnf
@@ -32,9 +32,6 @@
                         | [#xF900-#xFDCF] 
                         | [#xFDF0-#xFFFD] 
                         | [#x10000-#xEFFFF] 
-[158s] PN_CHARS_U       ::=  PN_CHARS_BASE 
-                        | '_' 
-                        | ':'
 [160s] PN_CHARS         ::= PN_CHARS_U 
                         | "-" 
                         | [0-9] 
@@ -42,3 +39,5 @@
                         | [#x0300-#x036F] 
                         | [#x203F-#x2040] 
 [162s] HEX              ::= [0-9] | [A-F] | [a-f]
+[164s] PN_CHARS_U       ::=  PN_CHARS_BASE 
+                        | '_' 

--- a/spec/nquads.bnf
+++ b/spec/nquads.bnf
@@ -32,6 +32,8 @@
                         | [#xF900-#xFDCF] 
                         | [#xFDF0-#xFFFD] 
                         | [#x10000-#xEFFFF] 
+[164s] PN_CHARS_U       ::=  PN_CHARS_BASE 
+                        | '_' 
 [160s] PN_CHARS         ::= PN_CHARS_U 
                         | "-" 
                         | [0-9] 
@@ -39,5 +41,3 @@
                         | [#x0300-#x036F] 
                         | [#x203F-#x2040] 
 [162s] HEX              ::= [0-9] | [A-F] | [a-f]
-[164s] PN_CHARS_U       ::=  PN_CHARS_BASE 
-                        | '_' 


### PR DESCRIPTION
Aligning the productions for PN_CHARS_U that are different between Turtle/TriG and N-Triples/N-Quads.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/13.html" title="Last updated on Feb 13, 2023, 7:49 PM UTC (d9ad264)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/13/1514c6b...d9ad264.html" title="Last updated on Feb 13, 2023, 7:49 PM UTC (d9ad264)">Diff</a>