### PR TITLE
Canonicalization

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -609,7 +609,11 @@
       <a href="#sec-grammar-comments">Comments</a>,
       better mirroring [[RDF12-TURTLE]].</li>
     <li>Updated the <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
-      grammar production to be consisten with with Turtle.</li>
+      grammar production to be consistent with with Turtle.
+      Formerly, <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
+      included "`:`" in N-Triples and N-Quads, but not in Turtle and TriG.
+      <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> is a component
+      of <a href="#grammar-production-PN_CHARS_U">BLANK_NODE_LABEL</a>.</li>
     <li>Separated <a href="#security"></a> from <a href="#sec-mediatype"></a>
       and updated language.</li>
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -272,6 +272,80 @@
       <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
       <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>
+
+  <div class="issue markdown" data-number="16">
+    <p>Re-consider the use of `UCHAR` and `ECHAR` escapes in N-Triples/N-Quads canonicalization.
+      The 1.1-based recommendation prohibits the use of `UCHAR` (`U+XXXX`)
+      and allows `ECHAR` only for `U+0022` (quote `\"`),
+      `U+005C` (backslash `\\`),
+      `U+000A` (<code title="LINE FEED"><sub>LF</sub></code> `\n`),
+      and `U+000D` (<code title="CARRIAGE RETURN"><sub>CR</sub></code> `\r`).
+      However, the use of control characters can obfuscate text when presented,
+      creating a potential security concern.</p>
+
+    <p>A future version may consider requiring all characters between
+      `U+0000` and `U+001F` (other than `U+000A` (<code title="LINE FEED"><sub>LF</sub></code>)
+      and `U+000D` (<code title="CARRIAGE RETURN"><sub>CR</sub></code>))
+      to be represented using `UCHAR`.</p>
+  </div>
+</section>
+
+<section id="privacy-considerations">
+  <h2>Privacy Considerations</h2>
+  <p class="ednote">TODO</p>  
+</section>
+
+<section id="security">
+  <h2>Security Considerations</h2>
+
+  <p>The <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
+    production allows the use of unescaped control characters.
+    Although this specification does not directly expose this content to an end user,
+    it might be presented through 
+    If presented through a user agent, this may cause the </p>
+
+  <p>N-Quads is a general-purpose assertion language;
+    applications may evaluate given data to infer more assertions or to dereference IRIs,
+    invoking the security considerations of the scheme for that IRI.
+    Note in particular, the privacy issues in [[!RFC3023]] section 10 for HTTP IRIs.
+    Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
+    as well as the dereferencing of unintended IRIs.
+    Care must be taken to align the trust in consulted resources with the sensitivity of
+    the intended use of the data;
+    inferences of potential medical treatments would likely require different trust than inferences
+    for trip planning.</p>
+
+  <p>N-Quads is used to express arbitrary application data; security considerations
+    will vary by domain of use. Security tools and protocols applicable to text
+    (e.g. PGP encryption, MD5 sum validation, password-protected compression)
+    may also be used on N-Quads documents.
+    Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
+
+  <p>N-Quads can express data which is presented to the user, for example, RDF Schema labels.
+    Application rendering strings retrieved from untrusted N-Quads documents,
+    or using unescaped characters,
+    must ensure that malignant strings may not be used to mislead the reader.
+    The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
+    provide additional guidance around the expression of arbitrary data and markup.</p>
+
+  <p>N-Quads uses IRIs as term identifiers.
+    Applications interpreting data expressed in N-Quads should address the security issues of
+    [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
+    [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
+
+  <p>Multiple IRIs may have the same appearance. Characters in different scripts may
+    look similar (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
+    A character followed by combining characters may have the same visual representation
+    as another character
+    (LATIN SMALL LETTER E followed by COMBINING ACUTE ACCENT has the same visual representation
+    as LATIN SMALL LETTER E WITH ACUTE).
+    <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
+    Any person or application that is writing or interpreting data in
+    TriG must take care to use the IRI that matches the intended semantics,
+    and avoid IRIs that make look similar.
+    Further information about matching of similar characters can be found
+    in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
+     [[[RFC3987]]] [[RFC3987]] Section 8.</p>
 </section>
 
 <section id="privacy-considerations">

--- a/spec/index.html
+++ b/spec/index.html
@@ -234,10 +234,6 @@
       _:bob <http://xmlns.com/foaf/0.1/knows> _:alice .
       -->
     </pre>
-    <p class="issue" data-number="2">
-      Note open <a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_30">erratum</a> on aligning the definition and production
-      for blank node lables with Turtle.
-    </p>
   </section>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -245,9 +245,13 @@
     The grammar for the language is the same.</p>
 
   <p class="note">A canonical form of N-Quads can be used to ensure
-    that the form of a quad is unique for a given choice of
-    <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node indentifiers</a>
-    and the ordering of those quads in a document.</p>
+    that variations in the syntactic representation of terms
+    within that quad is determined; each code point
+    can be represented by only one of
+    <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
+    <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
+    and unencoded character
+    where the relevant production allows for a choice in representation.</p>
 
   <p>Canonical N-Quads has the following additional constraints on layout:</p>
   <ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -302,8 +302,8 @@
   <p>The <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
     production allows the use of unescaped control characters.
     Although this specification does not directly expose this content to an end user,
-    it might be presented through 
-    If presented through a user agent, this may cause the </p>
+    it might be presented through a user agent, which may cause the presented text to 
+    be obfuscated due to presentation of such characters.</p>
 
   <p>N-Quads is a general-purpose assertion language;
     applications may evaluate given data to infer more assertions or to dereference IRIs,
@@ -325,7 +325,8 @@
   <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
     Application rendering strings retrieved from untrusted N-Quads documents,
     or using unescaped characters,
-    must ensure that strings may not be used to mislead the reader.
+must try to prevent such strings from being used to mislead the reader,
+through warnings and any other appropriate means.
     The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
     provide additional guidance around the expression of arbitrary data and markup.</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -244,8 +244,10 @@
     less variability in layout.
     The grammar for the language is the same.</p>
 
-  <p class="note">Even when not explicitly serializing
-    canonical N-Quads, implementers are encouraged to produce this form.</p>
+  <p class="note">A canonical form for N-Quads can be used to ensure
+    that the form of a quad is unique for a given choice of
+    <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node indentifiers</a>
+    and the ordering of those quads in a document.</p>
 
   <p>Canonical N-Quads has the following additional constraints on layout:</p>
   <ul>
@@ -306,9 +308,9 @@
     be obfuscated due to presentation of such characters.</p>
 
   <p>N-Quads is a general-purpose assertion language;
-    applications may evaluate given data to infer more assertions or to dereference IRIs,
+    applications may evaluate given data to infer more assertions or to dereference <a>IRIs</a>,
     invoking the security considerations of the scheme for that IRI.
-    Note in particular, the privacy issues in [[!RFC3023]] section 10 for HTTP IRIs.
+    Note in particular, the privacy issues in [[RFC3023]] section 10 for HTTP IRIs.
     Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
     as well as the dereferencing of unintended IRIs.
     Care must be taken to align the trust in consulted resources with the sensitivity of
@@ -316,38 +318,39 @@
     inferences of potential medical treatments would likely require different trust than inferences
     for trip planning.</p>
 
-  <p>N-Quads is used to express arbitrary application data; security considerations
-    will vary by domain of use. Security tools and protocols applicable to text
+  <p>N-Quads is used to express arbitrary application data;
+    security considerations will vary by domain of use.
+    Security tools and protocols applicable to text
     (for example, PGP encryption, checksum validation, password-protected compression)
     may also be used on N-Quads documents.
     Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
 
   <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
-    Application rendering strings retrieved from untrusted N-Quads documents,
+    Applications rendering strings retrieved from untrusted N-Quads documents,
     or using unescaped characters,
-must try to prevent such strings from being used to mislead the reader,
-through warnings and any other appropriate means.
+    SHOULD prevent such strings from being used to mislead the reader,
+    through warnings and any other appropriate means.
     The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
     provide additional guidance around the expression of arbitrary data and markup.</p>
 
   <p>N-Quads uses IRIs as term identifiers.
-    Applications interpreting data expressed in N-Quads should address the security issues of
+    Applications interpreting data expressed in N-Quads SHOULD address the security issues of
     [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
     [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
 
-  <p>Multiple IRIs may have the same appearance. Characters in different scripts may
-    look similar (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
+  <p>Multiple <a>IRIs</a> may have the same appearance.
+    Characters in different scripts may look similar
+    (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
     A character followed by combining characters may have the same visual representation
-    as another character
-    (LATIN SMALL LETTER E followed by COMBINING ACUTE ACCENT has the same visual representation
-    as LATIN SMALL LETTER E WITH ACUTE).
+    as another character (LATIN SMALL LETTER "E" followed by COMBINING ACUTE ACCENT
+    has the same visual representation as LATIN SMALL LETTER "E" WITH ACUTE).
     <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
-    Any person or application that is writing or interpreting data in
-    TriG must take care to use the IRI that matches the intended semantics,
+    Any person or application that is writing or interpreting data in N-Quads
+    must take care to use the IRI that matches the intended semantics,
     and avoid IRIs that may look similar.
     Further information about matching of similar characters can be found
     in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
-     [[[RFC3987]]] [[RFC3987]] Section 8.</p>
+    [[[RFC3987]]] [[RFC3987]] Section 8.</p>
 </section>
 
 <section id="privacy-considerations">

--- a/spec/index.html
+++ b/spec/index.html
@@ -318,7 +318,7 @@
     inferences of potential medical treatments would likely require different trust than inferences
     for trip planning.</p>
 
-  <p>N-Quads is used to express arbitrary application data;
+  <p>The N-Quads language is used to express arbitrary application data;
     security considerations will vary by domain of use.
     Security tools and protocols applicable to text
     (for example, PGP encryption, checksum validation, password-protected compression)

--- a/spec/index.html
+++ b/spec/index.html
@@ -328,12 +328,11 @@
   <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
     Applications rendering strings retrieved from untrusted N-Quads documents,
     or using unescaped characters,
-    SHOULD prevent such strings from being used to mislead the reader,
-    through warnings and any other appropriate means.
+    SHOULD ensure that malignant strings may not be used to mislead the reader.
     The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
     provide additional guidance around the expression of arbitrary data and markup.</p>
 
-  <p>N-Quads uses IRIs as term identifiers.
+  <p>N-Quads uses <a>IRIs</a> as term identifiers.
     Applications interpreting data expressed in N-Quads SHOULD address the security issues of
     [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
     [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -352,66 +352,6 @@
     Any person or application that is writing or interpreting data in N-Quads
     must take care to use the IRI that matches the intended semantics,
     and avoid IRIs that may look similar.
-    Further information about matching of similar characters can be found
-    in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
-    [[[RFC3987]]] [[RFC3987]] Section 8.</p>
-</section>
-
-<section id="privacy-considerations">
-  <h2>Privacy Considerations</h2>
-  <p class="ednote">TODO</p>  
-</section>
-
-<section id="security">
-  <h2>Security Considerations</h2>
-
-  <p>The <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
-    production allows the use of unescaped control characters.
-    Although this specification does not directly expose this content to an end user,
-    it might be presented through a user agent, which may cause the presented text to 
-    be obfuscated due to presentation of such characters.</p>
-
-  <p>N-Quads is a general-purpose assertion language;
-    applications may evaluate given data to infer more assertions or to dereference <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>,
-    invoking the security considerations of the scheme for that IRI.
-    Note in particular, the privacy issues in [[RFC3023]] section 10 for HTTP IRIs.
-    Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
-    as well as the dereferencing of unintended IRIs.
-    Care must be taken to align the trust in consulted resources with the sensitivity of
-    the intended use of the data;
-    inferences of potential medical treatments would likely require different trust than inferences
-    for trip planning.</p>
-
-  <p>The N-Quads language is used to express arbitrary application data;
-    security considerations will vary by domain of use.
-    Security tools and protocols applicable to text
-    (for example, PGP encryption, checksum validation, password-protected compression)
-    may also be used on N-Quads documents.
-    Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
-
-  <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
-    Applications rendering strings retrieved from untrusted N-Quads documents,
-    or using unescaped characters,
-    SHOULD use warnings and other appropriate means to limit the possibility
-    that malignant strings might be used to mislead the reader.
-    The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
-    provide additional guidance around the expression of arbitrary data and markup.</p>
-
-  <p>N-Quads uses <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> as term identifiers.
-    Applications interpreting data expressed in N-Quads SHOULD address the security issues of
-    [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
-    [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
-
-  <p>Multiple <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may have the same appearance.
-    Characters in different scripts may look similar (for instance,
-    a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
-    A character followed by combining characters may have the same visual representation
-    as another character (for example, LATIN SMALL LETTER "E" followed by COMBINING ACUTE
-    ACCENT has the same visual representation as LATIN SMALL LETTER "E" WITH ACUTE).
-    <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
-    Any person or application that is writing or interpreting data in N-Quads
-    must take care to use the IRI that matches the intended semantics,
-    and avoid IRIs that may look similar.
     Further information about matching visually similar characters can be found
     in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
     [[[RFC3987]]] [[RFC3987]] Section 8.</p>
@@ -655,7 +595,47 @@
     <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF)
       or \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>
     <dt>Security considerations:</dt>
-    <dd>See <a href="#security" class="sectionRef"></a>.</dd>
+    <dd>N-Quads is a general-purpose assertion language;
+      applications may evaluate given data to infer more assertions or to dereference IRIs,
+      invoking the security considerations of the scheme for that IRI.
+      Note in particular, the privacy issues in [[!RFC3023]] section 10 for HTTP IRIs.
+      Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
+      as well as the dereferencing of unintended IRIs.
+      Care must be taken to align the trust in consulted resources with the sensitivity of
+      the intended use of the data;
+      inferences of potential medical treatments would likely require different trust than inferences
+      for trip planning.</dd>
+
+    <dd>N-Quads is used to express arbitrary application data; security considerations
+      will vary by domain of use. Security tools and protocols applicable to text
+      (e.g. PGP encryption, MD5 sum validation, password-protected compression)
+      may also be used on N-Quads documents.
+      Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</dd>
+    <dd>N-Quads can express data which is presented to the user, for example, RDF Schema labels.
+      Application rendering strings retrieved from untrusted N-Quads documents
+      must ensure that malignant strings may not be used to mislead the reader.
+      The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
+      provide additional guidance around the expression of arbitrary data and markup.</dd>
+    <dd>N-Quads uses IRIs as term identifiers.
+      Applications interpreting data expressed in N-Quads should address the security issues of
+      [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
+      [[[!RFC3986]]] [[!RFC3986]] Section 7.</dd>
+
+    <dd>Multiple IRIs may have the same appearance. Characters in different scripts may
+      look similar (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
+      A character followed by combining characters may have the same visual representation
+      as another character
+      (LATIN SMALL LETTER E followed by COMBINING ACUTE ACCENT has the same visual representation
+      as LATIN SMALL LETTER E WITH ACUTE).
+      <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
+      Any person or application that is writing or interpreting data in
+      TriG must take care to use the IRI that matches the intended semantics,
+      and avoid IRIs that make look similar.
+      Further information about matching of similar characters can be found
+      in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
+       [[[RFC3987]]] [[RFC3987]] Section 8.
+    </dd>
+
     <dt>Interoperability considerations:</dt>
     <dd>There are no known interoperability issues.</dd>
     <dt>Published specification:</dt>

--- a/spec/index.html
+++ b/spec/index.html
@@ -318,14 +318,14 @@
 
   <p>N-Quads is used to express arbitrary application data; security considerations
     will vary by domain of use. Security tools and protocols applicable to text
-    (for example, PGP encryption, MD5 sum validation, password-protected compression)
+    (for example, PGP encryption, checksum validation, password-protected compression)
     may also be used on N-Quads documents.
     Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
 
   <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
     Application rendering strings retrieved from untrusted N-Quads documents,
     or using unescaped characters,
-    must ensure that malignant strings may not be used to mislead the reader.
+    must ensure that strings may not be used to mislead the reader.
     The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
     provide additional guidance around the expression of arbitrary data and markup.</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -93,7 +93,7 @@
     also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>'
-    (optionally proceded by white space and/or a comment),
+    (optionally followed by white space and/or a comment),
     and a new line (optional at the end of a document).</p>
 
   <pre id="ex-comments" class="example nquads" data-transform="updateExample"
@@ -246,7 +246,7 @@
 
   <p class="note">A canonical form of N-Quads can be used to ensure
     that variations in the syntactic representation of terms
-    within that quad is determined; each code point
+    within that quad are determined; each code point
     can be represented by only one of
     <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
     <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
@@ -259,8 +259,8 @@
       <code>subject</code>,
       <code>predicate</code>, 
       <code>object</code>,
-      and <code>graphLabel</code>
-      where it MUST be a single space (<code>U+0020</code>).</li>
+      and <code>graphLabel</code>,
+      any of which MUST be a single space (<code>U+0020</code>).</li>
     <li><a data-cite="RDF12-CONCEPTS#literal">Literals</a> with the
       datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
@@ -413,7 +413,7 @@
 
     <p>A <dfn class="no=export">blank line</dfn>, consisting of only white space and/or a comment,
       may appear wherever a <code><a href="#grammar-production-statement">statement</a></code> production is allowed,
-      and are treated as white space.</p>
+      and is treated as white space.</p>
 
     <p class="note">As with, N-Triples [[RDF12-N-TRIPLES]],
       N-Quads allows only horizontal white space  (tab U+0009 or space U+0020).</p>
@@ -553,9 +553,9 @@
       <a href="#sec-grammar-comments">Comments</a>,
       better mirroring [[RDF12-TURTLE]].</li>
     <li>Updated the <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
-      grammar production to be consistent with with Turtle.
+      grammar production to be consistent with Turtle.
       Formerly, <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a>
-      included "`:`" in N-Triples and N-Quads, but not in Turtle and TriG.
+      included "`:`" in N-Triples and N-Quads, but not in Turtle nor TriG.
       <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> is a component
       of <a href="#grammar-production-PN_CHARS_U">BLANK_NODE_LABEL</a>.</li>
     <li>Separated <a href="#security"></a> from <a href="#sec-mediatype"></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -125,7 +125,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>,
     <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>, an optional
     <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
-    and optional blank lines.
+    and optional <a>blank lines</a>.
     Comments may be given after a '<code>#</code>' that is not part of
     another lexical token and continue to the end of the line.</p>
 
@@ -259,26 +259,19 @@
       and <code>graphLabel</code> if present, MUST be a single space, 
       (<code>U+0020</code>).  All other locations that allow 
       white space MUST be empty.</li>
-    <li>There MUST be no comments.</li>
-    <li><code>HEX</code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
-    <li>Characters MUST NOT be represented by <code>UCHAR</code>.</li>
+    <li>There MUST be no comments or <a>blank lines</a>.</li>
+    <!--li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li-->
+    <li>Characters MUST NOT be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
-      only the characters 
+      the characters 
       <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
-       are encoded using <code>ECHAR</code>.
-      <code>ECHAR</code> MUST NOT be used for characters that are
+       MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
+      <code><a href="#grammar-production-ECHAR">ECHAR</a></code> MUST NOT be used for characters that are
       allowed directly in
-      <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>. </li>
-      <li>The token EOL MUST be a single <code>U+000A</code>.</li>
-      <li>The final EOL MUST be provided.</li>
+      <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>. </li>
+      <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
+      <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>
-  <div class="issue" data-number="2">
-    Note open errata:
-    <ul>
-      <li><a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_32">32 – Issues with N-Quads/N-Triples canonicalization</a>.</li>
-      <li><a href="https://www.w3.org/2001/sw/wiki/RDF1.1_Errata#erratum_33">33 – Ambiguity of canonical N-Triples</a></li>
-    </ul>
-  </div>
 </section>
 
 <section id="privacy-considerations">
@@ -395,7 +388,7 @@
 
     <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
 
-    <p>A blank line, consisting of only white space and/or a comment,
+    <p>A <dfn class="no=export">blank line</dfn>, consisting of only white space and/or a comment,
       may appear wherever a <code><a href="#grammar-production-statement">statement</a></code> production is allowed,
       and are treated as white space.</p>
 
@@ -528,7 +521,7 @@
     <li>Better align the use of white space and comments with [[RDF12-TURTLE]].</li>
     <li>Removed language about white space use between terminals that would otherwise
       be (mis-)recognized, is this can't happen in N-Triples.</li>
-    <li>Clarify the use of blank lines, including those composed of white space
+    <li>Clarify the use of <a>blank lines</a>, including those composed of white space
       and/or comments.
       Comments can appear at the end of a triple before the newline as
       was already evident from <a href="#ex-comments"></a>.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -250,7 +250,7 @@
     can be represented by only one of
     <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
     <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
-    and unencoded character
+    or unencoded character,
     where the relevant production allows for a choice in representation.</p>
 
   <p>Canonical N-Quads has the following additional constraints on layout:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -244,7 +244,7 @@
     less variability in layout.
     The grammar for the language is the same.</p>
 
-  <p class="note">A canonical form for N-Quads can be used to ensure
+  <p class="note">A canonical form of N-Quads can be used to ensure
     that the form of a quad is unique for a given choice of
     <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node indentifiers</a>
     and the ordering of those quads in a document.</p>
@@ -328,7 +328,8 @@
   <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
     Applications rendering strings retrieved from untrusted N-Quads documents,
     or using unescaped characters,
-    SHOULD ensure that malignant strings may not be used to mislead the reader.
+    SHOULD use warnings and other appropriate means to limit the possibility
+    that malignant strings might be used to mislead the reader.
     The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
     provide additional guidance around the expression of arbitrary data and markup.</p>
 
@@ -338,11 +339,11 @@
     [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
 
   <p>Multiple <a>IRIs</a> may have the same appearance.
-    Characters in different scripts may look similar
-    (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
+    Characters in different scripts may look similar (for instance,
+    a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
     A character followed by combining characters may have the same visual representation
-    as another character (LATIN SMALL LETTER "E" followed by COMBINING ACUTE ACCENT
-    has the same visual representation as LATIN SMALL LETTER "E" WITH ACUTE).
+    as another character (for example, LATIN SMALL LETTER "E" followed by COMBINING ACUTE
+    ACCENT has the same visual representation as LATIN SMALL LETTER "E" WITH ACUTE).
     <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
     Any person or application that is writing or interpreting data in N-Quads
     must take care to use the IRI that matches the intended semantics,

--- a/spec/index.html
+++ b/spec/index.html
@@ -93,7 +93,7 @@
     also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
     These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
     This sequence is terminated by a '<code>.</code>'
-    (optionaly proceded by white space and/or a comment),
+    (optionally proceded by white space and/or a comment),
     and a new line (optional at the end of a document).</p>
 
   <pre id="ex-comments" class="example nquads" data-transform="updateExample"

--- a/spec/index.html
+++ b/spec/index.html
@@ -308,7 +308,7 @@
     be obfuscated due to presentation of such characters.</p>
 
   <p>N-Quads is a general-purpose assertion language;
-    applications may evaluate given data to infer more assertions or to dereference <a>IRIs</a>,
+    applications may evaluate given data to infer more assertions or to dereference <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>,
     invoking the security considerations of the scheme for that IRI.
     Note in particular, the privacy issues in [[RFC3023]] section 10 for HTTP IRIs.
     Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
@@ -333,12 +333,12 @@
     The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
     provide additional guidance around the expression of arbitrary data and markup.</p>
 
-  <p>N-Quads uses <a>IRIs</a> as term identifiers.
+  <p>N-Quads uses <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> as term identifiers.
     Applications interpreting data expressed in N-Quads SHOULD address the security issues of
     [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
     [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
 
-  <p>Multiple <a>IRIs</a> may have the same appearance.
+  <p>Multiple <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may have the same appearance.
     Characters in different scripts may look similar (for instance,
     a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
     A character followed by combining characters may have the same visual representation

--- a/spec/index.html
+++ b/spec/index.html
@@ -259,6 +259,11 @@
       and <code>graphLabel</code> if present, MUST be a single space, 
       (<code>U+0020</code>).  All other locations that allow 
       white space MUST be empty.</li>
+    <li><a data-cite="RDF12-CONCEPTS#literal">Literals</a> with the
+      datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
+      MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
+      and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
+    </li>
     <li>There MUST be no comments or <a>blank lines</a>.</li>
     <!--li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li-->
     <li>Characters MUST NOT be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.</li>
@@ -273,7 +278,7 @@
       <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>
 
-  <div class="issue markdown" data-number="16">
+  <div class="issue" data-number="16">
     <p>Re-consider the use of `UCHAR` and `ECHAR` escapes in N-Triples/N-Quads canonicalization.
       The 1.1-based recommendation prohibits the use of `UCHAR` (`U+XXXX`)
       and allows `ECHAR` only for `U+0022` (quote `\"`),

--- a/spec/index.html
+++ b/spec/index.html
@@ -292,7 +292,7 @@
     <p>A future version may consider requiring all characters between
       `U+0000` and `U+001F` (other than `U+000A` (<code title="LINE FEED"><sub>LF</sub></code>)
       and `U+000D` (<code title="CARRIAGE RETURN"><sub>CR</sub></code>))
-      along with `U+007F` <code title="delete">DEL</code>
+      along with `U+007F` (<code title="delete"><sub>DEL</sub></code>)
       to be represented using `UCHAR`.</p>
   </div>
 </section>
@@ -595,47 +595,7 @@
     <dd>Unicode code points may also be expressed using an \uXXXX (U+0 to U+FFFF)
       or \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-F]</dd>
     <dt>Security considerations:</dt>
-    <dd>N-Quads is a general-purpose assertion language;
-      applications may evaluate given data to infer more assertions or to dereference IRIs,
-      invoking the security considerations of the scheme for that IRI.
-      Note in particular, the privacy issues in [[!RFC3023]] section 10 for HTTP IRIs.
-      Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
-      as well as the dereferencing of unintended IRIs.
-      Care must be taken to align the trust in consulted resources with the sensitivity of
-      the intended use of the data;
-      inferences of potential medical treatments would likely require different trust than inferences
-      for trip planning.</dd>
-
-    <dd>N-Quads is used to express arbitrary application data; security considerations
-      will vary by domain of use. Security tools and protocols applicable to text
-      (e.g. PGP encryption, MD5 sum validation, password-protected compression)
-      may also be used on N-Quads documents.
-      Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</dd>
-    <dd>N-Quads can express data which is presented to the user, for example, RDF Schema labels.
-      Application rendering strings retrieved from untrusted N-Quads documents
-      must ensure that malignant strings may not be used to mislead the reader.
-      The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
-      provide additional guidance around the expression of arbitrary data and markup.</dd>
-    <dd>N-Quads uses IRIs as term identifiers.
-      Applications interpreting data expressed in N-Quads should address the security issues of
-      [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
-      [[[!RFC3986]]] [[!RFC3986]] Section 7.</dd>
-
-    <dd>Multiple IRIs may have the same appearance. Characters in different scripts may
-      look similar (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
-      A character followed by combining characters may have the same visual representation
-      as another character
-      (LATIN SMALL LETTER E followed by COMBINING ACUTE ACCENT has the same visual representation
-      as LATIN SMALL LETTER E WITH ACUTE).
-      <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
-      Any person or application that is writing or interpreting data in
-      TriG must take care to use the IRI that matches the intended semantics,
-      and avoid IRIs that make look similar.
-      Further information about matching of similar characters can be found
-      in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
-       [[[RFC3987]]] [[RFC3987]] Section 8.
-    </dd>
-
+    <dd>See <a href="#security" class="sectionRef"></a>.</dd>
     <dt>Interoperability considerations:</dt>
     <dd>There are no known interoperability issues.</dd>
     <dt>Published specification:</dt>

--- a/spec/index.html
+++ b/spec/index.html
@@ -322,11 +322,11 @@
 
   <p>N-Quads is used to express arbitrary application data; security considerations
     will vary by domain of use. Security tools and protocols applicable to text
-    (e.g. PGP encryption, MD5 sum validation, password-protected compression)
+    (for example, PGP encryption, MD5 sum validation, password-protected compression)
     may also be used on N-Quads documents.
     Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
 
-  <p>N-Quads can express data which is presented to the user, for example, RDF Schema labels.
+  <p>N-Quads can express data which is presented to the user, such as RDF Schema labels.
     Application rendering strings retrieved from untrusted N-Quads documents,
     or using unescaped characters,
     must ensure that malignant strings may not be used to mislead the reader.
@@ -347,7 +347,7 @@
     <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
     Any person or application that is writing or interpreting data in
     TriG must take care to use the IRI that matches the intended semantics,
-    and avoid IRIs that make look similar.
+    and avoid IRIs that may look similar.
     Further information about matching of similar characters can be found
     in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
      [[[RFC3987]]] [[RFC3987]] Section 8.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -249,18 +249,17 @@
 
   <p>Canonical N-Quads has the following additional constraints on layout:</p>
   <ul>
-    <li>The white space following <code>subject</code>,
+    <li>White space MUST NOT be used except after
+      <code>subject</code>,
       <code>predicate</code>, 
       <code>object</code>,
-      and <code>graphLabel</code> if present, MUST be a single space, 
-      (<code>U+0020</code>).  All other locations that allow 
-      white space MUST be empty.</li>
+      and <code>graphLabel</code>
+      where it MUST be a single space (<code>U+0020</code>).</li>
     <li><a data-cite="RDF12-CONCEPTS#literal">Literals</a> with the
       datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
       and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
     </li>
-    <li>There MUST be no comments or <a>blank lines</a>.</li>
     <!--li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li-->
     <li>Characters MUST NOT be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
@@ -287,6 +286,7 @@
     <p>A future version may consider requiring all characters between
       `U+0000` and `U+001F` (other than `U+000A` (<code title="LINE FEED"><sub>LF</sub></code>)
       and `U+000D` (<code title="CARRIAGE RETURN"><sub>CR</sub></code>))
+      along with `U+007F` <code title="delete">DEL</code>
       to be represented using `UCHAR`.</p>
   </div>
 </section>


### PR DESCRIPTION
* Improve canonicalization section.
* Separate out Security Considerations from media type and add a Privacy Considerations stub.
* Reference issue #16 as a future direction for canonicalization.
* Add prohibition on using a datatype IRI if the datatype is xsd:string when canonicalizing (see w3c/rdf-star-wg#9).

This will ultimately make its way into N-Triples, as well.

Note separate of Security Considerations and a phrase about the potential for unescaped characters to obfuscate a string presentation.

For #2.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/17.html" title="Last updated on Mar 30, 2023, 8:58 PM UTC (ef93071)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/17/274e733...ef93071.html" title="Last updated on Mar 30, 2023, 8:58 PM UTC (ef93071)">Diff</a>