### PR TITLE
Update the use of ECHAR and UCHAR in canonical N-Quads.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -266,35 +266,19 @@
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
       and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
     </li>
-    <!--li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li-->
+    <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
     <li>Characters MUST NOT be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
       the characters 
       <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
-       MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
-      <code><a href="#grammar-production-ECHAR">ECHAR</a></code> MUST NOT be used for characters that are
-      allowed directly in
-      <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>. </li>
+      MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
+      Characters in the range from <code>U+0000</code> to <code>U+001F</code> and <code>U+007F</code>
+      not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
+      MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
+      All other characters MUST be represented by their native [[UNICODE]] representation..</li>
       <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
       <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>
-
-  <div class="issue" data-number="16">
-    <p>Re-consider the use of `UCHAR` and `ECHAR` escapes in N-Triples/N-Quads canonicalization.
-      The 1.1-based recommendation prohibits the use of `UCHAR` (`U+XXXX`)
-      and allows `ECHAR` only for `U+0022` (quote `\"`),
-      `U+005C` (backslash `\\`),
-      `U+000A` (<code title="LINE FEED"><sub>LF</sub></code> `\n`),
-      and `U+000D` (<code title="CARRIAGE RETURN"><sub>CR</sub></code> `\r`).
-      However, the use of control characters can obfuscate text when presented,
-      creating a potential security concern.</p>
-
-    <p>A future version may consider requiring all characters between
-      `U+0000` and `U+001F` (other than `U+000A` (<code title="LINE FEED"><sub>LF</sub></code>)
-      and `U+000D` (<code title="CARRIAGE RETURN"><sub>CR</sub></code>))
-      along with `U+007F` (<code title="delete"><sub>DEL</sub></code>)
-      to be represented using `UCHAR`.</p>
-  </div>
 </section>
 
 <section id="privacy-considerations">

--- a/spec/index.html
+++ b/spec/index.html
@@ -244,6 +244,10 @@
     a completely specified layout.
     The grammar for the language is the same.</p>
 
+  <p>Canonical N-Quads extends
+    <a data-cite="RDF12-N-TRIPLES#canonical-ntriples">Canonical N-Triples</a> in [[RDF12-N-TRIPLES]]
+    to include <code><a href="#grammar-production-graphLabel">graphLabel</a></code>.</p>
+
   <p>While the N-Quads syntax allows choices for the representation and layout of RDF data,
     the canonical form of N-Quads provides a unique syntactic representation of any quad.
     Each code point

--- a/spec/index.html
+++ b/spec/index.html
@@ -273,10 +273,17 @@
     </li>
     <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
-      the characters 
-      <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
+      the characters
+      <code>U+0008</code> (<code title="BACKSPACE"><sub>BS</sub></code>),
+      <code>U+0009</code> (<code title="HORIZONTAL TAB"><sub>HT</sub></code>),
+      <code>U+000A</code> (<code title="LINE FEED"><sub>LF</sub></code>),
+      <code>U+000C</code> (<code title="FORM FEED"><sub>FF</sub></code>),
+      <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>)),
+      <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>)), and
+      <code>U+005C</code> (<code title="BACKSLASH">\</code>))
       MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
-      Characters in the range from <code>U+0000</code> to <code>U+001F</code> and <code>U+007F</code>
+      Characters in the range from <code>U+0000</code> to <code>U+001F</code>
+      and <code>U+007F</code>  (<code title="delete"><sub>DEL</sub></code>)
       that are not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
       MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
       All other characters MUST be represented by their native [[UNICODE]] representation.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -241,17 +241,18 @@
   <h2>A Canonical form of N-Quads</h2>
 
   <p>This section defines a canonical form of N-Quads which has
-    less variability in layout.
+    a completely specified layout.
     The grammar for the language is the same.</p>
 
-  <p class="note">A canonical form of N-Quads can be used to ensure
-    that variations in the syntactic representation of terms
-    within that quad are determined; each code point
+  <p>While the N-Quads syntax allows choices for the representation and layout of RDF data,
+    the canonical form of N-Quads provides a unique syntactic representation of any quad.
+    Each code point
     can be represented by only one of
     <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
     <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
     or unencoded character,
-    where the relevant production allows for a choice in representation.</p>
+    where the relevant production allows for a choice in representation.
+    Each quad is represented entirely on a single line with specified white space.</p>
 
   <p>Canonical N-Quads has the following additional constraints on layout:</p>
   <ul>
@@ -275,8 +276,8 @@
       that are not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
       MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
       All other characters MUST be represented by their native [[UNICODE]] representation.</li>
-      <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
-      <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
+    <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
+    <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -243,7 +243,7 @@
 
   <p>This section defines a canonical form of N-Quads which has
     a completely specified layout.
-    The grammar for the language is the same.</p>
+    The grammar for the language remains unchanged.</p>
 
   <p>Canonical N-Quads extends
     <a data-cite="RDF12-N-TRIPLES#canonical-ntriples">Canonical N-Triples</a> in [[RDF12-N-TRIPLES]]
@@ -279,9 +279,9 @@
       <code>U+0009</code> (<code title="HORIZONTAL TAB"><sub>HT</sub></code>),
       <code>U+000A</code> (<code title="LINE FEED"><sub>LF</sub></code>),
       <code>U+000C</code> (<code title="FORM FEED"><sub>FF</sub></code>),
-      <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>)),
-      <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>)), and
-      <code>U+005C</code> (<code title="BACKSLASH">\</code>))
+      <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>),
+      <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>), and
+      <code>U+005C</code> (<code title="BACKSLASH">\</code>)
       MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
       Characters in the range from <code>U+0000</code> to <code>U+001F</code>
       and <code>U+007F</code>  (<code title="delete"><sub>DEL</sub></code>)

--- a/spec/index.html
+++ b/spec/index.html
@@ -267,7 +267,6 @@
       and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
     </li>
     <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
-    <li>Characters MUST NOT be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
       the characters 
       <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>

--- a/spec/index.html
+++ b/spec/index.html
@@ -279,12 +279,12 @@
       <code>U+0009</code> (<code title="HORIZONTAL TAB"><sub>HT</sub></code>),
       <code>U+000A</code> (<code title="LINE FEED"><sub>LF</sub></code>),
       <code>U+000C</code> (<code title="FORM FEED"><sub>FF</sub></code>),
-      <code>U+000D</code>  (<code title="CARRIAGE RETURN"><sub>CR</sub></code>),
+      <code>U+000D</code> (<code title="CARRIAGE RETURN"><sub>CR</sub></code>),
       <code>U+0022</code> (<code title="DOUBLE QUOTE">&quot;</code>), and
       <code>U+005C</code> (<code title="BACKSLASH">\</code>)
       MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
       Characters in the range from <code>U+0000</code> to <code>U+001F</code>
-      and <code>U+007F</code>  (<code title="delete"><sub>DEL</sub></code>)
+      and <code>U+007F</code> (<code title="delete"><sub>DEL</sub></code>)
       that are not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
       MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
       All other characters MUST be represented by their native [[UNICODE]] representation.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -243,7 +243,7 @@
 
   <p>This section defines a canonical form of N-Quads which has
     a completely specified layout.
-    The grammar for the language remains unchanged.</p>
+    The grammar for the language is unchanged.</p>
 
   <p>Canonical N-Quads extends
     <a data-cite="RDF12-N-TRIPLES#canonical-ntriples">Canonical N-Triples</a> in [[RDF12-N-TRIPLES]]

--- a/spec/index.html
+++ b/spec/index.html
@@ -272,9 +272,9 @@
       <code>U+0022</code>, <code>U+005C</code>, <code>U+000A</code>, <code>U+000D</code>
       MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.
       Characters in the range from <code>U+0000</code> to <code>U+001F</code> and <code>U+007F</code>
-      not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
+      that are not represented using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>
       MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>.
-      All other characters MUST be represented by their native [[UNICODE]] representation..</li>
+      All other characters MUST be represented by their native [[UNICODE]] representation.</li>
       <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>U+000A</code>.</li>
       <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -46,8 +46,9 @@
     .separated thead tr th { border:1px solid black; padding: .2em; }
     .separated tbody tr td { border:1px solid black; text-align: center; }
     .separated tbody tr td.r { text-align: right; padding: .5em; }
-    .grammar td { font-family: monospace;}
+    .grammar td { font-family: monospace; vertical-align: top; }
     .grammar-literal { color: gray;}
+    .grammar_comment { color: #A52A2A; font-style: italic; }
     code {color: #ff4500;}  /* Old W3C Style */
   </style>
 </head>


### PR DESCRIPTION
Fixes #16.

Previously discussed in the RCH WG https://www.w3.org/2023/03/15-rch-minutes.html#r01.

cc/ @philarcher @yamdan


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/27.html" title="Last updated on Apr 18, 2023, 11:13 PM UTC (8021d97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/27/6aff865...8021d97.html" title="Last updated on Apr 18, 2023, 11:13 PM UTC (8021d97)">Diff</a>