### PR TITLE
Specify IRIREF and quoted-triple wrappers more accurately.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -203,7 +203,8 @@
       <code><a href="#grammar-production-subject">subject</a></code>,
       <code><a href="#grammar-production-predicate">predicate</a></code>, and
       <code><a href="#grammar-production-object">object</a></code>
-      preceded by <code>&lt;&lt;</code> and followed by <code>&gt;&gt;</code>.
+      preceded by two concatenated <code>&lt;</code> characters, each having the code point <span class="codepoint">U+003C</span>, and
+      followed by two concatenated <code>&gt;</code> characters, each having the code point <span class="codepoint">U+003E</span>.
       Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
       may be recursive.
      </p>
@@ -222,7 +223,9 @@
 
     <p>
       As in N-Triples, <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may be written only as absolute IRIs.
-      IRIs are enclosed in '&lt;' and '&gt;' and may contain numeric escape sequences (described below).
+      IRIs are preceded by <code>&lt;</code> (code point <span class="codepoint">U+003C</span>) and
+      followed by <code>&gt;</code> (code point <span class="codepoint">U+003E</span>),
+      and may contain numeric escape sequences (described below).
       For example <code>&lt;http://example.org/#green-goblin&gt;</code>.
     </p>
   </section>


### PR DESCRIPTION
See w3c/rdf-n-triples#36.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/42.html" title="Last updated on Jul 21, 2023, 10:42 PM UTC (2fb2842)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/42/a23c829...2fb2842.html" title="Last updated on Jul 21, 2023, 10:42 PM UTC (2fb2842)">Diff</a>