### PR TITLE
Note that datatype can't be used when canonicalizing language-tagged strings

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -323,9 +323,19 @@
       and <code>graphLabel</code>,
       any of which MUST be a single space (<code>U+0020</code>).</li>
     <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
-      datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
+      datatypes <code>http://www.w3.org/2001/XMLSchema#string</code> and
+      <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
-      and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
+      and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
+      and <a href="#grammar-production-LANGTAG">LANGTAG</a>,
+      as appropriate.
+      <div class="issue" data-number="45">
+        [[RDF12-CONCEPTS]] allows implementations to convert
+        <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tags</a> to lower case.
+        This represents a potential interoperability issue if language tags
+        are not converted to lower case uniformly, as different implementations
+        may end up using different canonical representations of such language tags.
+      </div>
     </li>
     <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only uppercase letters (<code>[A-F]</code>).</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,


### PR DESCRIPTION
… and reference the issue on interoperability considerations of normalizing LANGTAG.

For #45.

Note that future decisions may clarify the normalization of LANGTAG. Also, this will need to be updated for `rdf:dirLangString`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/46.html" title="Last updated on Aug 5, 2023, 8:18 PM UTC (1b55812)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/46/d6c87f8...1b55812.html" title="Last updated on Aug 5, 2023, 8:18 PM UTC (1b55812)">Diff</a>