### PR TITLE
minor markup fix in index.html

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -333,10 +333,10 @@
     <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
       datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
-      and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.
+      and are represented using only <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>.
     </li>
     <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only digits (<code>[0-9]</code>) and uppercase letters (<code>[A-F]</code>).</li>
-    <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>:
+    <li>Within <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>:
       <ul>
         <li>Characters
           <code>BS</code> (backspace, code point <code class="codepoint">U+0008</code>),


### PR DESCRIPTION
noticed after https://github.com/w3c/rdf-n-quads/pull/50 was merged


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-n-quads/pull/51.html" title="Last updated on Sep 29, 2023, 9:28 PM UTC (9641cce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/51/4510249...TallTed:9641cce.html" title="Last updated on Sep 29, 2023, 9:28 PM UTC (9641cce)">Diff</a>