### PR TITLE
Simplify grammar tokens

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -274,7 +274,7 @@
     <h3>RDF Blank Nodes</h3>
     <p>
       As in N-Triples,
-      <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> are expressed as <code>_:</code>
+      <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> are expressed as <a href="#cp-underscore-colon"><code>_:</code></a>
       followed by a blank node label which is a series of name characters.
       The characters in the label are built upon <a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a>,
       liberalized as follows:
@@ -537,6 +537,11 @@
           <td><code title="digit nine">9</code></td>
           <td>Digit nine</td>
         </tr>
+        <tr id="cp-colon">
+          <td><code class="codepoint">U+003B</code></td>
+          <td><code title="colon">:</code></td>
+          <td>Colon</td>
+        </tr>
         <tr id="cp-less-than">
           <td><code class="codepoint">U+003C</code></td>
           <td><code title="less than sign">&lt;</code></td>
@@ -601,6 +606,8 @@
       <dd>two concatenated greater-than sign characters, each having the code point <code class="codepoint">U+003E</code></dd>
       <dt id="cp-double-circumflex"><code>^^</code></dt>
       <dd>two concatenated circumflex accent characters, each having the code point <code class="codepoint">U+005E</code></dd>
+      <dt id="cp-underscore-colon"><code>_:</code></dt>
+      <dd><a href="#cp-underscore"><code title="underscore">_</code></a> followed by <a href="#cp-colon"><code title="colon">:</code></a></dd>
     </dl>
   </section>
 </section>
@@ -631,7 +638,7 @@
             <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
           </td>
           <td>
-            The string after <code>_:</code>,
+            The string after <a href="#cp-underscore-colon"><code>_:</code></a>,
             is a key in <a href="#bnodeLabels">bnodeLabels</a>.
             If there is no corresponding blank node in the map,
             one is allocated.

--- a/spec/index.html
+++ b/spec/index.html
@@ -124,7 +124,7 @@
     associated with the triple within an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
     also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
     These may be separated by white space (<a href="#cp-space"><code title="space">spaces</code></a>, and/or <a href="#cp-tab"><code title="horizontal tab">tabs</code></a>).
-    This sequence is terminated by a <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
+    This sequence is terminated by a <a href="#cp-full-stop"><code title="full stop">.</code></a>
     (optionally followed by white space and/or a comment),
     and a new line (optional at the end of a document).</p>
 
@@ -358,9 +358,9 @@
           <a href="#cp-backslash"><code title="backslash">\</code></a>
           MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.</li>
         <li>Characters in the range from <code class="codepoint">U+0000</code> to <code class="codepoint">U+0007</code>,
-          <code>VT</code> (vertical tab, code point <code class="codepoint">U+000B</code>),
+          <a href="#cp-vertical-tab"><code title="vertical tab">VT</code></a>,
           characters in the range from <code class="codepoint">U+000E</code> to <code class="codepoint">U+001F</code>,
-          <code>DEL</code> (delete, code point <code class="codepoint">U+007F</code>),
+          <a href="#cp-delete"><code title="delete">DEL</code></a>,
           and characters not matching the <a data-cite="XML11#charsets">Char</a> production from [[XML11]]
           MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>
           using a lowercase <code>\u</code> with 4 <code><a href="#grammar-production-HEX">HEX</a></code>es.</li>
@@ -497,6 +497,11 @@
           <td><code title="line feed">LF</code></td>
           <td>Line feed</td>
         </tr>
+        <tr id="cp-vertical-tab">
+          <td><code class="codepoint">U+000B</code></td>
+          <td><code title="vertical tab">VT</code></td>
+          <td>Vertical tab</td>
+        </tr>
         <tr id="cp-form-feed">
           <td><code class="codepoint">U+000C</code></td>
           <td><code title="form feed">FF</code></td>
@@ -576,6 +581,11 @@
           <td><code class="codepoint">U+005F</code></td>
           <td><code title="underscore">_</code></td>
           <td>Underscore</td>
+        </tr>
+        <tr id="cp-delete">
+          <td><code class="codepoint">U+007F</code></td>
+          <td><code title="delete">DEL</code></td>
+          <td>Delete</td>
         </tr>
         <tr id="cp-middle-dot">
           <td><code class="codepoint">U+00B7</code></td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -65,7 +65,14 @@
         table { word-break: normal; }
         .separated thead tr th { border: 1px solid black; padding: .2em; min-width: 10vw }
         .separated tbody tr td { border: 1px solid black; text-align: center; min-width: 10vw }
-}
+    }
+
+    table.cp-definitions { border-collapse:collapse; background-color: #DDDDFF}
+
+    table.cp-definitions,
+    table.cp-definitions th,
+    table.cp-definitions td { border:1px solid black; padding:0.2em; }
+    table.cp-definitions td:nth-child(2) { text-align: center; }
   </style>
 </head>
 <body>
@@ -116,8 +123,8 @@
     identifying a <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
     associated with the triple within an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>,
     also known as a <a data-cite="RDF12-CONCEPTS#dfn-quad">quad</a>.
-    These may be separated by white space (spaces <code>#x20</code> or tabs <code>#x9</code>).
-    This sequence is terminated by a '<code>.</code>'
+    These may be separated by white space (<a href="#cp-space"><code title="space">spaces</code></a>, and/or <a href="#cp-tab"><code title="horizontal tab">tabs</code></a>).
+    This sequence is terminated by a <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
     (optionally followed by white space and/or a comment),
     and a new line (optional at the end of a document).</p>
 
@@ -151,7 +158,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>, an optional
     <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
     and optional <a>blank lines</a>.
-    Comments may be given after a '<code>#</code>' that is not part of
+    Comments may be given after a <a href="#cp-number-sign"><code title="number sign">#</code></a> that is not part of
     another lexical token and continue to the end of the line.</p>
 
   <section id="simple-triples">
@@ -172,10 +179,10 @@
       or <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>) labeling what
       <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
       in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to.
-      White space (spaces, code point <code class="codepoint">U+0020</code>, and/or tabs, code point <code class="codepoint">U+0009</code>) may surround terms,
+      White space (<a href="#cp-space"><code title="space">spaces</code></a>, and/or <a href="#cp-tab"><code title="horizontal tab">tabs</code></a>) may surround terms,
       except where significant as noted in the <a href="#n-quads-grammar">grammar</a>.</p>
 
-    <p>Comments are treated as white space, and may be given after a '<code>#</code>' that is not part of
+    <p>Comments are treated as white space, and may be given after a <a href="#cp-number-sign"><code title="number sign">#</code></a> that is not part of
       another lexical token and continue to the end of the line.</p>
 
     <p>The <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a> can be omitted, in which case the triples are considered
@@ -203,8 +210,8 @@
       <code><a href="#grammar-production-subject">subject</a></code>,
       <code><a href="#grammar-production-predicate">predicate</a></code>, and
       <code><a href="#grammar-production-object">object</a></code>
-      preceded by two concatenated <code>&lt;</code> characters, each having the code point <code class="codepoint">U+003C</code>, and
-      followed by two concatenated <code>&gt;</code> characters, each having the code point <code class="codepoint">U+003E</code>.
+      preceded by <a href="#cp-double-lt"><code>&lt;&lt;</code></a>, and
+      followed by <a href="#cp-double-gt"><code>&gt;&gt;</code></a>.
       Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
       may be nested.
      </p>
@@ -223,8 +230,8 @@
 
     <p>
       As in N-Triples, <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may be written only as <a data-cite="RFC3986#section-5">resolved</a> IRIs.
-      IRIs are preceded by <code>&lt;</code> (code point <code class="codepoint">U+003C</code>) and
-      followed by <code>&gt;</code> (code point <code class="codepoint">U+003E</code>),
+      IRIs are preceded by <a href="#cp-less-than"><code title="less-than sign">&lt;</code></a> and
+      followed by <a href="#cp-greater-than"><code title="greater-than sign">&gt;</code></a>,
       and may contain numeric escape sequences (described below).
       For example <code>&lt;http://example.org/#green-goblin&gt;</code>.
     </p>
@@ -237,27 +244,26 @@
       <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a> are used to identify values such as strings, numbers, dates.</p>
 
     <p>The representation of the <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> consists of an
-      initial delimiter <code>&quot;</code> (quotation mark, code point <code class="codepoint">U+0022</code>),
+      initial delimiter <a href="#cp-quotation-mark"><code title="quotation mark">&quot;</code></a>,
       a sequence of permitted characters or numeric escape sequence or string escape sequence,
       and a final delimiter.</p>
 
-    <p>Literals may not contain the characters <code>&quot;</code> (quotation mark, code point <code class="codepoint">U+0022</code>),
-      <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>), or
-      <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code>)
+    <p>Literals may not contain the characters <a href="#cp-quotation-mark"><code title="quotation mark">&quot;</code></a>,
+      <a href="#cp-line-feed"><code title="line feed">LF</code></a>, or
+      <a href="#cp-carriage-return"><code title="carriage return">CR</code></a>
       except in their escaped forms.
-      In addition '<code>\</code>' (backslash, code point <code class="codepoint">U+005C</code>)
+      In addition <a href="#cp-backslash"><code title="backslash">\</code></a>
       may not appear in any quoted literal except as part of an escape sequence
-      and a <code>&quot;</code> (quotation mark, code point <code class="codepoint">U+0022</code>) character
+      and a <a href="#cp-quotation-mark"><code title="quotation mark">&quot;</code></a> character
       can only be included in a quoted literal using an escape sequence.
       </p>
 
     <p>The corresponding <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
       is the characters between the delimiters, after processing any escape sequences.
       If present, the <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
-      is preceded by an '<code>@</code>' (at sign, code point <code class="codepoint">U+0040</code>).
+      is preceded by an <a href="#cp-at-sign"><code title="at sign">@</code></a>.
       If there is no language tag, there may be a <a data-cite="RDF12-CONCEPTS#dfn-datatype-iri">datatype IRI</a>,
-      preceded by two concatenated <code>^</code> characters,
-      each having the code point <code class="codepoint">U+005E</code>.
+      preceded by <a href="#cp-double-circumflex"><code>^^</code></a>.
       If there is no datatype IRI and no language tag
       it is a <a data-cite="RDF12-CONCEPTS#dfn-simple-literal">simple literal</a>
       and the datatype is <code>http://www.w3.org/2001/XMLSchema#string</code>.
@@ -274,13 +280,15 @@
       liberalized as follows:
     </p>
     <ul>
-      <li>The characters <code>_</code> and <code>[0-9]</code> may appear anywhere in a blank node label.</li>
-      <li>The character <code>.</code> may appear anywhere except the first or last character.</li>
+      <li>The characters <a href="#cp-underscore"><code title="underscore">_</code></a> and
+        the digit characters <a href="#cp-zero"><code title="digit zero">0</code></a>–<a href="#cp-nine"><code title="digit nine">9</code></a>, inclusive
+        may appear anywhere in a blank node label.</li>
+      <li>The character <a href="#cp-full-stop"><code title="full stop">.</code></a> may appear anywhere except the first or last character.</li>
       <li>The characters
-        <code>-</code> (hyphen, <code class="codepoint">U+2010</code>),
-        <code>·</code> (middle dot, <code class="codepoint">U+00B7</code>),
-        &#x203F;&nbsp; (undertie, <code class="codepoint">U+203F</code>),
-        &#x2040;&nbsp; (character tie, <code class="codepoint">U+2040</code>),
+        <a href="#cp-hyphen"><code title="hyphen">-</code></a>,
+        <a href="#cp-middle-dot"><code title="middle dot">·</code></a>,
+        <a href="#cp-undertie"><code title="undertie">&#x203F;</code></a>,
+        <a href="#cp-character-tie"><code title="character tie">&#x2040;</code></a>,
         and
         the combining diacritical marks (<code class="codepoint">U+0300</code>
                                       to <code class="codepoint">U+036F</code>)
@@ -329,23 +337,25 @@
       <code>predicate</code>, 
       <code>object</code>,
       and <code>graphLabel</code>,
-      any of which MUST be a single space (code point <code class="codepoint">U+0020</code>).</li>
+      any of which MUST be a single <a href="#cp-space"><code title="space">space</code></a>.</li>
     <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
       datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
       and are represented using only <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>.
     </li>
-    <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only digits (<code>[0-9]</code>) and uppercase letters (<code>[A-F]</code>).</li>
+    <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only digits
+      (<code>[</code><a href="#cp-zero"><code title="digit zero">0</code></a>–<a href="#cp-nine"><code title="digit nine">9</code></a><code>]</code>)
+      and uppercase letters (<code>[</code><a href="#cp-uppercase-a"><code title="latin capital letter A">A</code></a>–<a href="#cp-uppercase-f"><code title="latin capital letter F">F</code></a><code>]</code>).</li>
     <li>Within <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>:
       <ul>
         <li>Characters
-          <code>BS</code> (backspace, code point <code class="codepoint">U+0008</code>),
-          <code>HT</code> (horizontal tab, code point <code class="codepoint">U+0009</code>),
-          <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>),
-          <code>FF</code> (form feed, code point <code class="codepoint">U+000C</code>),
-          <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code>),
-          <code>&quot;</code> (quotation mark, code point <code class="codepoint">U+0022</code>), and
-          <code>\</code> (backslash, code point <code class="codepoint">U+005C</code>)
+          <a href="#cp-backspace"><code title="backspace">BS</code></a>,
+          <a href="#cp-tab"><code title="horizontal tab">HT</code></a>,
+          <a href="#cp-line-feed"><code title="line feed">LF</code></a>,
+          <a href="#cp-form-feed"><code title="form feed">FF</code></a>,
+          <a href="#cp-carriage-return"><code title="carriage return">CR</code></a>,
+          <a href="#cp-quotation-mark"><code title="quotation mark">&quot;</code></a>, and
+          <a href="#cp-backslash"><code title="backslash">\</code></a>
           MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.</li>
         <li>Characters in the range from <code class="codepoint">U+0000</code> to <code class="codepoint">U+0007</code>,
           <code>VT</code> (vertical tab, code point <code class="codepoint">U+000B</code>),
@@ -360,7 +370,7 @@
           MUST be represented by their native [[UNICODE]] representation.</li>
       </ul>
     </li>
-    <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>).</li>
+    <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <a href="#cp-line-feed"><code title="line feed">LF</code></a>.</li>
     <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
   </ul>
 </section>
@@ -419,29 +429,29 @@
   <section id="sec-grammar-ws">
     <h3>White Space</h3>
 
-    <p>White space (tab, code point <code class="codepoint">U+0009</code>, or space, code point <code class="codepoint">U+0020</code>) is allowed outside of terminals.
+    <p>White space (<a href="#cp-space"><code title="space">spaces</code></a>, and/or <a href="#cp-tab"><code title="horizontal tab">tabs</code></a>) is allowed outside of terminals.
       Rule names below in capitals indicate where white space is significant.
-</p>
+    </p>
 
-    <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
+    <p>White space is significant in the production <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>.</p>
 
     <p>A <dfn class="no=export">blank line</dfn>, consisting of only white space and/or a comment,
       may appear wherever a <code><a href="#grammar-production-statement">statement</a></code> production is allowed,
       and is treated as white space.</p>
 
     <p class="note">As with, N-Triples [[RDF12-N-TRIPLES]],
-      N-Quads allows only horizontal white space  (tab, code point <code class="codepoint">U+0009</code> or space, code point <code  class="codepoint">U+0020</code>).</p>
+      N-Quads allows only horizontal white space (<a href="#cp-space"><code title="space">spaces</code></a> or <a href="#cp-tab"><code title="horizontal tab">tabs</code></a>).</p>
   </section>
 
   <section id="sec-grammar-comments">
     <h3>Comments</h3>
 
-    <p>Comments in N-Quads start at '<code>#</code>'
-      outside an <a href="#grammar-production-IRIREF">IRIREF</a> or <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
+    <p>Comments in N-Quads start at <a href="#cp-number-sign"><code title="number sign">#</code></a>
+      outside an <code><a href="#grammar-production-IRIREF">IRIREF</a></code> or <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,</code>
       and continue to the end of line
       (marked by characters
-      <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code> or
-      <code>LF</code> (line feed, code point <code class="codepoint">U+000A</code>))
+      <a href="#cp-carriage-return"><code title="carriage return">CR</code></a> or
+      <a href="#cp-line-feed"><code title="line feed">LF</code></a>)
       or end of file if there is no end of line after the comment
       marker.
       Comments are treated as white space.</p>
@@ -459,6 +469,140 @@
 
     <div data-include="nquads-bnf.html"></div>
   </section>
+
+  <section>
+    <h2>Selected Terminal Literal Strings</h2>
+    <p>This document uses some specific terminal literal strings [[EBNF-NOTATION]].
+      To clarify the Unicode code points used for these terminal literal strings, the following
+      table describes specific characters and sequences used throughout this document.</p>
+
+    <!-- Selected unicode character descriptions, taken from https://en.wikipedia.org/wiki/List_of_Unicode_characters -->
+    <table class="cp-definitions">
+      <thead>
+        <tr><th>Code</th><th>Glyph</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr id="cp-backspace">
+          <td><code class="codepoint">U+0008</code></td>
+          <td><code title="backspace">BS</code></td>
+          <td>Backspace</td>
+        </tr>
+        <tr id="cp-tab">
+          <td><code class="codepoint">U+0009</code></td>
+          <td><code title="horizontal tab">HT</code></td>
+          <td>Horizontal tab</td>
+        </tr>
+        <tr id="cp-line-feed">
+          <td><code class="codepoint">U+000A</code></td>
+          <td><code title="line feed">LF</code></td>
+          <td>Line feed</td>
+        </tr>
+        <tr id="cp-form-feed">
+          <td><code class="codepoint">U+000C</code></td>
+          <td><code title="form feed">FF</code></td>
+          <td>Form feed</td>
+        </tr>
+        <tr id="cp-carriage-return">
+          <td><code class="codepoint">U+000D</code></td>
+          <td><code title="carriage return">CR</code></td>
+          <td>Carriage return</td>
+        </tr>
+        <tr id="cp-quotation-mark">
+          <td><code class="codepoint">U+0022</code></td>
+          <td><code title="quotation mark">&quot;</code></td>
+          <td>Quotation mark</td>
+        </tr>
+        <tr id="cp-number-sign">
+          <td><code class="codepoint">U+0023</code></td>
+          <td><code title="number sign">#</code></td>
+          <td>Number sign</td>
+        </tr>
+        <tr id="cp-hyphen">
+          <td><code class="codepoint">U+002D</code></td>
+          <td><code title="hyphen">-</code></td>
+          <td>Hyphen</td>
+        </tr>
+        <tr id="cp-full-stop">
+          <td><code class="codepoint">U+002E</code></td>
+          <td><code title="full stop">.</code></td>
+          <td>Full stop</td>
+        </tr>
+        <tr id="cp-zero">
+          <td><code class="codepoint">U+0030</code></td>
+          <td><code title="digit zero">0</code></td>
+          <td>Digit zero</td>
+        </tr>
+        <tr id="cp-nine">
+          <td><code class="codepoint">U+0039</code></td>
+          <td><code title="digit nine">9</code></td>
+          <td>Digit nine</td>
+        </tr>
+        <tr id="cp-less-than">
+          <td><code class="codepoint">U+003C</code></td>
+          <td><code title="less than sign">&lt;</code></td>
+          <td>Less-than sign</td>
+        </tr>
+        <tr id="cp-greater-than">
+          <td><code class="codepoint">U+003E</code></td>
+          <td><code title="greater-than sign">&gt;</code></td>
+          <td>Greater-than sign</td>
+        </tr>
+        <tr id="cp-at-sign">
+          <td><code class="codepoint">U+0040</code></td>
+          <td><code title="at sign">@</code></td>
+          <td>At sign</td>
+        </tr>
+        <tr id="cp-uppercase-a">
+          <td><code class="codepoint">U+0041</code></td>
+          <td><code title="latin capital letter A">A</code></td>
+          <td>Latin capital letter E</td>
+        </tr>
+        <tr id="cp-uppercase-f">
+          <td><code class="codepoint">U+0046</code></td>
+          <td><code title="latin capital letter F">F</code></td>
+          <td>Latin capital letter F</td>
+        </tr>
+        <tr id="cp-backslash">
+          <td><code class="codepoint">U+005C</code></td>
+          <td><code title="backslash">\</code></td>
+          <td>Backslash</td>
+        </tr>
+        <tr id="cp-underscore">
+          <td><code class="codepoint">U+005F</code></td>
+          <td><code title="underscore">_</code></td>
+          <td>Underscore</td>
+        </tr>
+        <tr id="cp-middle-dot">
+          <td><code class="codepoint">U+00B7</code></td>
+          <td><code title="middle dot">·</code></td>
+          <td>Middle dot</td>
+        </tr>
+        <tr id="cp-undertie">
+          <td><code class="codepoint">U+203F</code></td>
+          <td><code title="undertie">&#x203F;</code></td>
+          <td>Undertie</td>
+        </tr>
+        <tr id="cp-character-tie">
+          <td><code class="codepoint">U+2040</code></td>
+          <td><code title="character tie">&#x2040;</code></td>
+          <td>Character tie</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>Other short terminal literal strings are composed of specific sequences of Unicode characters:</p>
+  
+    <dl>
+      <dt id="cp-space"><code title="space">space</code></dt>
+      <dd><code class="codepoint">U+0020</code></dd>
+      <dt id="cp-double-lt"><code>&lt;&lt;</code></dt>
+      <dd>two concatenated less-than sign characters, each having the code point <code class="codepoint">U+003C</code></dd>
+      <dt id="cp-double-gt"><code>&gt;&gt;</code></dt>
+      <dd>two concatenated greater-than sign characters, each having the code point <code class="codepoint">U+003E</code></dd>
+      <dt id="cp-double-circumflex"><code>^^</code></dt>
+      <dd>two concatenated circumflex accent characters, each having the code point <code class="codepoint">U+005E</code></dd>
+    </dl>
+  </section>
 </section>
 
 <section id="sec-parsing">
@@ -471,7 +615,9 @@
 
   <section id="sec-parsing-terms">
     <h3>RDF Term Constructors</h3>
-    <p>This table maps productions and lexical tokens to <code>RDF terms</code> or components of <code>RDF terms</code> listed in <a href="#sec-parsing" class="sectionRef"></a>:</p>
+    <p>This table maps productions and lexical tokens to <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>
+      or components of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>
+      listed in <a href="#sec-parsing" class="sectionRef"></a>:</p>
     <table class="simple">
       <thead>
         <tr><th>production</th><th>type</th><th>procedure</th></tr>
@@ -485,7 +631,7 @@
             <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
           </td>
           <td>
-            The string after '<code>_:</code>',
+            The string after <code>_:</code>,
             is a key in <a href="#bnodeLabels">bnodeLabels</a>.
             If there is no corresponding blank node in the map,
             one is allocated.
@@ -512,7 +658,7 @@
             <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a>
           </td>
           <td>
-            The characters following the <code>@</code> form the language tag.
+            The characters following the <a href="#cp-at-sign"><code title="at sign">@</code></a> form the language tag.
           </td>
         </tr>
         <tr id="handle-STRING_LITERAL_QUOTE">
@@ -523,7 +669,7 @@
             <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">RDF lexical form</a>
           </td>
           <td>
-            The characters between the outermost quotation marks (<code>&quot;</code>) are taken,
+            The characters between the outermost quotation marks (<a href="#cp-quotation-mark"><code title="quotation mark">&quot;</code></a>) are taken,
             with escape sequences unescaped,
             to form the <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">string</a> of the <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>.
           </td>
@@ -536,13 +682,13 @@
           </td>
           <td>
             The literal has a <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of the first rule argument,
-            <code>STRING_LITERAL_QUOTE</code>,
-            and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> of <code>LANGTAG</code>
+            <code><a href="#grammar-production-STRING_LITERAL_QUOTE" class="type lexicalForm">STRING_LITERAL_QUOTE</a></code>,
+            and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> of <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code>
             or a datatype IRI of <code>iri</code>,
             depending on which rule matched the input.
-            If the <code>LANGTAG</code> rule matched,
+            If the <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> rule matched,
             the datatype is <code>rdf:langString</code>
-            and the language tag is <code>LANGTAG</code>.
+            and the language tag is <code><code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code></code>.
             If neither a language tag nor a datatype IRI is provided,
             the literal has a datatype of <code>xsd:string</code>.
           </td>
@@ -600,7 +746,7 @@
 <section id="security" class="appendix informative">
   <h2>Security Considerations</h2>
 
-  <p>The <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
+  <p>The <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>
     production allows the use of unescaped control characters.
     Although this specification does not directly expose this content to an end user,
     it might be presented through a user agent, which may cause the presented text to 
@@ -681,8 +827,9 @@
     <dt>Encoding considerations:</dt>
     <dd>The syntax of N-Quads is expressed over code points in Unicode [[!UNICODE]].
       The encoding is always UTF-8 [[!UTF-8]].</dd>
-    <dd>Unicode code points may also be expressed using an `\uXXXX` (<code class="codepoint">U+0000</code> to <code class="codepoint">U+FFFF</code>)
-      or `\UXXXXXXXX` syntax (for <code class="codepoint">U+10000</code> onwards) where `X` is a hexadecimal digit `[0-9A-F]`</dd>
+    <dd>Unicode code points may also be expressed using an <code>\uXXXX</code> (<code class="codepoint">U+0000</code> to <code class="codepoint">U+FFFF</code>)
+      or <code>\UXXXXXXXX</code> syntax (for code points up to <code class="codepoint">U+10FFFF</code>)
+      where `X` is a hexadecimal digit `[0-9A-F]`</dd>
     <dt>Security considerations:</dt>
     <dd>See <a href="#security" class="sectionRef"></a>.</dd>
     <dt>Interoperability considerations:</dt>

--- a/spec/nquads-bnf.html
+++ b/spec/nquads-bnf.html
@@ -11,7 +11,7 @@
       <td>[2]</td>
       <td><code>statement</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> <a href="#grammar-production-graphLabel">graphLabel</a><code class="grammar-opt">?</code> "<code class="grammar-literal">.</code>"</td>
+      <td><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> <a href="#grammar-production-graphLabel">graphLabel</a><code class="grammar-opt">?</code> '<code class="grammar-literal">.</code>'</td>
     </tr>
     <tr id="grammar-production-subject">
       <td>[3]</td>
@@ -41,13 +41,13 @@
       <td>[7]</td>
       <td><code>literal</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANGTAG">LANGTAG</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">^^</code>' <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANGTAG">LANGTAG</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-quotedTriple">
       <td>[8]</td>
       <td><code>quotedTriple</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;&lt;</code>" <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> "<code class="grammar-literal">&gt;&gt;</code>"</td>
+      <td>'<code class="grammar-literal">&lt;&lt;</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
     </tr>
     <tr id="grammar-declaration-terminals">
       <td colspan="4">
@@ -58,19 +58,19 @@
       <td>[10]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&gt;</code>"</td>
+      <td>'<code class="grammar-literal">&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&gt;</code>'</td>
     </tr>
     <tr id="grammar-production-BLANK_NODE_LABEL">
       <td>[11]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">_:</code>" <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td>'<code class="grammar-literal">_:</code>' <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANGTAG">
       <td>[12]</td>
       <td><code>LANGTAG</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
+      <td>'<code class="grammar-literal">@</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">-</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
       <td>[13]</td>
@@ -82,13 +82,13 @@
       <td>[14]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
-      <td><code class="grammar-paren">(</code>"<code class="grammar-literal">\u</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">\U</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
+      <td><code class="grammar-paren">(</code>'<code class="grammar-literal">\u</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">\U</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
       <td>[15]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">\</code>" <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf&quot;&apos;</code><code class="grammar-brac">]</code></td>
+      <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
       <td>[16]</td>
@@ -165,13 +165,13 @@
       <td>[17]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">_</code>"</td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">_</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
       <td>[18]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">-</code>" <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
+      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>'  <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-HEX">
       <td>[19]</td>

--- a/spec/nquads.bnf
+++ b/spec/nquads.bnf
@@ -11,11 +11,11 @@ quotedTriple      ::= '<<' subject predicate object '>>'
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )*
+LANGTAG           ::= '@' [a-zA-Z]+ ( '-' [a-zA-Z0-9]+ )*
 STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
-UCHAR             ::= ( "\u" HEX HEX HEX HEX )
-                    | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )
-ECHAR             ::= ("\" [tbnrf"'])
+UCHAR             ::= ( '\u' HEX HEX HEX HEX )
+                    | ( '\U' HEX HEX HEX HEX HEX HEX HEX HEX )
+ECHAR             ::= ('\' [tbnrf"'])
 PN_CHARS_BASE     ::= ([A-Z]
                     | [a-z]
                     | [#x00C0-#x00D6]
@@ -32,7 +32,7 @@ PN_CHARS_BASE     ::= ([A-Z]
                     | [#x10000-#xEFFFF])
 PN_CHARS_U        ::=  PN_CHARS_BASE | '_'
 PN_CHARS          ::= (PN_CHARS_U
-                    | "-"
+                    | '-'
                     | [0-9]
                     | #x00B7
                     | [#x0300-#x036F]


### PR DESCRIPTION
* Use single quotes in BNF.
* Use table to make grammar literal terminals explicit with simplified use within the document.

This mirrors w3c/rdf-turtle#46.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/52.html" title="Last updated on Oct 10, 2023, 7:26 PM UTC (8e9eea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/52/cb668fe...8e9eea2.html" title="Last updated on Oct 10, 2023, 7:26 PM UTC (8e9eea2)">Diff</a>