### PR TITLE
add some missing `<code>` tags to index.html

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -423,7 +423,7 @@
       Rule names below in capitals indicate where white space is significant.
 </p>
 
-    <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>.</p>
+    <p>White space is significant in the production <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>.</p>
 
     <p>A <dfn class="no=export">blank line</dfn>, consisting of only white space and/or a comment,
       may appear wherever a <code><a href="#grammar-production-statement">statement</a></code> production is allowed,
@@ -437,7 +437,7 @@
     <h3>Comments</h3>
 
     <p>Comments in N-Quads start at '<code>#</code>'
-      outside an <a href="#grammar-production-IRIREF">IRIREF</a> or <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
+      outside an <code><a href="#grammar-production-IRIREF">IRIREF</a></code> or <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>,
       and continue to the end of line
       (marked by characters
       <code>CR</code> (carriage return, code point <code class="codepoint">U+000D</code> or
@@ -600,7 +600,7 @@
 <section id="security" class="appendix informative">
   <h2>Security Considerations</h2>
 
-  <p>The <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>
+  <p>The <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>
     production allows the use of unescaped control characters.
     Although this specification does not directly expose this content to an end user,
     it might be presented through a user agent, which may cause the presented text to 


### PR DESCRIPTION
Both `<code><a ...>...</a></code>` and `<a ...><code>...</code></a>` existed before this PR. Both still exist, and so far as I can tell, both render as intended.

Still, it might be better to settle on always `<code><a ...>...</a></code>` or always `<a ...><code>...</code></a>`. If so, I lean toward the latter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-n-quads/pull/54.html" title="Last updated on Oct 12, 2023, 9:03 PM UTC (8595823)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/54/5842d6a...TallTed:8595823.html" title="Last updated on Oct 12, 2023, 9:03 PM UTC (8595823)">Diff</a>