### PR TITLE
code-anchor inversion

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -206,10 +206,10 @@
       <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>.</p>
 
     <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
-      is represented as a <code><a href="#grammar-production-quotedTriple">quotedTriple</a></code> with
-      <code><a href="#grammar-production-subject">subject</a></code>,
-      <code><a href="#grammar-production-predicate">predicate</a></code>, and
-      <code><a href="#grammar-production-object">object</a></code>
+      is represented as a <a href="#grammar-production-quotedTriple"><code>quotedTriple</code></a> with
+      <a href="#grammar-production-subject"><code>subject</code></a>,
+      <a href="#grammar-production-predicate"><code>predicate</code></a>, and
+      <a href="#grammar-production-object"><code>object</code></a>
       preceded by <a href="#cp-double-lt"><code>&lt;&lt;</code></a>, and
       followed by <a href="#cp-double-gt"><code>&gt;&gt;</code></a>.
       Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
@@ -318,14 +318,14 @@
 
   <p>Canonical N-Quads extends
     <a data-cite="RDF12-N-TRIPLES#canonical-ntriples">Canonical N-Triples</a> in [[RDF12-N-TRIPLES]]
-    to include <code><a href="#grammar-production-graphLabel">graphLabel</a></code>.</p>
+    to include <a href="#grammar-production-graphLabel"><code>graphLabel</code></a>.</p>
 
   <p>While the N-Quads syntax allows choices for the representation and layout of RDF data,
     the canonical form of N-Quads provides a unique syntactic representation of any quad.
     Each code point
     can be represented by only one of
-    <code><a href="#grammar-production-UCHAR">UCHAR</a></code>,
-    <code><a href="#grammar-production-ECHAR">ECHAR</a></code>,
+    <a href="#grammar-production-UCHAR"><code>UCHAR</code></a>,
+    <a href="#grammar-production-ECHAR"><code>ECHAR</code></a>,
     or unencoded character,
     where the relevant production allows for a choice in representation.
     Each quad is represented entirely on a single line with specified white space.</p>
@@ -341,12 +341,12 @@
     <li><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
       datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
       MUST NOT use the datatype IRI part of the <a href="#grammar-production-literal">literal</a>,
-      and are represented using only <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>.
+      and are represented using only <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>.
     </li>
-    <li><code><a href="#grammar-production-HEX">HEX</a></code> MUST use only digits
+    <li><a href="#grammar-production-HEX"><code>HEX</code></a> MUST use only digits
       (<code>[</code><a href="#cp-zero"><code title="digit zero">0</code></a>–<a href="#cp-nine"><code title="digit nine">9</code></a><code>]</code>)
       and uppercase letters (<code>[</code><a href="#cp-uppercase-a"><code title="latin capital letter A">A</code></a>–<a href="#cp-uppercase-f"><code title="latin capital letter F">F</code></a><code>]</code>).</li>
-    <li>Within <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>:
+    <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>:
       <ul>
         <li>Characters
           <a href="#cp-backspace"><code title="backspace">BS</code></a>,
@@ -356,22 +356,22 @@
           <a href="#cp-carriage-return"><code title="carriage return">CR</code></a>,
           <a href="#cp-quotation-mark"><code title="quotation mark">&quot;</code></a>, and
           <a href="#cp-backslash"><code title="backslash">\</code></a>
-          MUST be encoded using <code><a href="#grammar-production-ECHAR">ECHAR</a></code>.</li>
+          MUST be encoded using <a href="#grammar-production-ECHAR"><code>ECHAR</code></a>.</li>
         <li>Characters in the range from <code class="codepoint">U+0000</code> to <code class="codepoint">U+0007</code>,
           <a href="#cp-vertical-tab"><code title="vertical tab">VT</code></a>,
           characters in the range from <code class="codepoint">U+000E</code> to <code class="codepoint">U+001F</code>,
           <a href="#cp-delete"><code title="delete">DEL</code></a>,
           and characters not matching the <a data-cite="XML11#charsets">Char</a> production from [[XML11]]
-          MUST be represented by <code><a href="#grammar-production-UCHAR">UCHAR</a></code>
-          using a lowercase <code>\u</code> with 4 <code><a href="#grammar-production-HEX">HEX</a></code>es.</li>
+          MUST be represented by <a href="#grammar-production-UCHAR"><code>UCHAR</code></a>
+          using a lowercase <code>\u</code> with 4 <a href="#grammar-production-HEX"><code>HEX</code></a>es.</li>
         <li>All characters not required to be represented by
-          <code><a href="#grammar-production-ECHAR">ECHAR</a></code> or
-          <code><a href="#grammar-production-UCHAR">UCHAR</a></code>
+          <a href="#grammar-production-ECHAR"><code>ECHAR</code></a> or
+          <a href="#grammar-production-UCHAR"><code>UCHAR</code></a>
           MUST be represented by their native [[UNICODE]] representation.</li>
       </ul>
     </li>
-    <li>The token <code><a href="#grammar-production-EOL">EOL</a></code> MUST be a single <a href="#cp-line-feed"><code title="line feed">LF</code></a>.</li>
-    <li>The final <code><a href="#grammar-production-EOL">EOL</a></code> MUST be provided.</li>
+    <li>The token <a href="#grammar-production-EOL"><code>EOL</code></a> MUST be a single <a href="#cp-line-feed"><code title="line feed">LF</code></a>.</li>
+    <li>The final <a href="#grammar-production-EOL"><code>EOL</code></a> MUST be provided.</li>
   </ul>
 </section>
 
@@ -433,10 +433,10 @@
       Rule names below in capitals indicate where white space is significant.
     </p>
 
-    <p>White space is significant in the production <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>.</p>
+    <p>White space is significant in the production <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>.</p>
 
     <p>A <dfn class="no=export">blank line</dfn>, consisting of only white space and/or a comment,
-      may appear wherever a <code><a href="#grammar-production-statement">statement</a></code> production is allowed,
+      may appear wherever a <a href="#grammar-production-statement"><code>statement</code></a> production is allowed,
       and is treated as white space.</p>
 
     <p class="note">As with, N-Triples [[RDF12-N-TRIPLES]],
@@ -698,13 +698,13 @@
           </td>
           <td>
             The literal has a <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a> of the first rule argument,
-            <code><a href="#grammar-production-STRING_LITERAL_QUOTE" class="type lexicalForm">STRING_LITERAL_QUOTE</a></code>,
-            and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> of <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code>
+            <a href="#grammar-production-STRING_LITERAL_QUOTE" class="type lexicalForm"><code>STRING_LITERAL_QUOTE</code></a>,
+            and either a <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> of <a href="#grammar-production-LANGTAG" class="type langTag"><code>LANGTAG</code></a>
             or a datatype IRI of <code>iri</code>,
             depending on which rule matched the input.
-            If the <code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code> rule matched,
+            If the <a href="#grammar-production-LANGTAG" class="type langTag"><code>LANGTAG</code></a> rule matched,
             the datatype is <code>rdf:langString</code>
-            and the language tag is <code><code><a href="#grammar-production-LANGTAG" class="type langTag">LANGTAG</a></code></code>.
+            and the language tag is <a href="#grammar-production-LANGTAG" class="type langTag"><code>LANGTAG</code></a>.
             If neither a language tag nor a datatype IRI is provided,
             the literal has a datatype of <code>xsd:string</code>.
           </td>
@@ -719,9 +719,9 @@
           <td>
             The <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
             is composed of the terms constructed from
-            the <code><a href="#grammar-production-subject">subject</a></code>,
-            <code><a href="#grammar-production-predicate">predicate</a></code>, and
-            <code><a href="#grammar-production-object">object</a></code> productions.
+            the <a href="#grammar-production-subject"><code>subject</code></a>,
+            <a href="#grammar-production-predicate"><code>predicate</code></a>, and
+            <a href="#grammar-production-object"><code>object</code></a> productions.
           </td>
         </tr>
       </tbody>
@@ -733,13 +733,13 @@
     <p>An <a>N-Quads document</a> defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>
       composed of <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graphs</a> composed of a set of
       <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triples</a>.
-      The  <code><a href="#grammar-production-statement">statement</a></code> production produces a
+      The  <a href="#grammar-production-statement"><code>statement</code></a> production produces a
       triple defined by the terms constructed for
-      <code><a href="#grammar-production-subject">subject</a></code>,
-      <code><a href="#grammar-production-predicate">predicate</a></code>, and
-      <code><a href="#grammar-production-object">object</a></code>.
+      <a href="#grammar-production-subject"><code>subject</code></a>,
+      a href="#grammar-production-predicate"><code>predicate</code></a>, and
+      <a href="#grammar-production-object"><code>object</code></a>>.
       This RDF triple is added to the <a data-cite="RDF12-CONCEPTS#dfn-named-graph">graph</a> labeled by
-      the production <code><a href="#grammar-production-graphLabel">graphLabel</a></code>,
+      the production <a href="#grammar-production-graphLabel"><code>graphLabel</code></a>,
       if no <code>graphLabel</code> is present the triple is added to the RDF dataset's default graph.</p>
   </section>
 </section>
@@ -762,7 +762,7 @@
 <section id="security" class="appendix informative">
   <h2>Security Considerations</h2>
 
-  <p>The <code><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></code>
+  <p>The <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>
     production allows the use of unescaped control characters.
     Although this specification does not directly expose this content to an end user,
     it might be presented through a user agent, which may cause the presented text to 


### PR DESCRIPTION
Invert `<code><a>...</a></code>` with `<a><code>...</code></a>`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/55.html" title="Last updated on Oct 12, 2023, 9:17 PM UTC (e277fdc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/55/18229b4...e277fdc.html" title="Last updated on Oct 12, 2023, 9:17 PM UTC (e277fdc)">Diff</a>