### PR TITLE
Should be "comment marker", not "comment arker".

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -452,7 +452,7 @@
       — marked by character
       <a href="#cp-carriage-return"><code title="carriage return">CR</code></a> or
       <a href="#cp-line-feed"><code title="line feed">LF</code></a> —
-      or to the end of file, if there is no end of line after the comment arker.
+      or to the end of file, if there is no end of line after the comment marker.
       Comments are treated as white space.</p>
   </section>
 


### PR DESCRIPTION
As reported in https://github.com/w3c/rdf-n-quads/pull/53#pullrequestreview-1675680359.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/56.html" title="Last updated on Oct 13, 2023, 7:46 PM UTC (b8401a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/56/01060e0...b8401a2.html" title="Last updated on Oct 13, 2023, 7:46 PM UTC (b8401a2)">Diff</a>