### PR TITLE
Add requirement that alphabetic characters in LANG_DIR be case mapped

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -361,6 +361,9 @@
     <li><a href="#grammar-production-HEX"><code>HEX</code></a> MUST use only digits
       (<code>[</code><a href="#cp-zero"><code title="digit zero">0</code></a>–<a href="#cp-nine"><code title="digit nine">9</code></a><code>]</code>)
       and uppercase letters (<code>[</code><a href="#cp-uppercase-a"><code title="latin capital letter A">A</code></a>–<a href="#cp-uppercase-f"><code title="latin capital letter F">F</code></a><code>]</code>).</li>
+    <li>Alphabetic characters in <a href="#grammar-production-LANG_DIR" class="type langDir"><code>LANG_DIR</code></a> MUST use only
+      the lowercase letters (<code>[</code><a href="#cp-lowercase-a"><code title="latin small letter A">a</code></a>–<a href="#cp-lowercase-z"><code title="latin small letter Z">z</code></a><code>]</code>)
+      with any uppercase letters <a data-cite="I18N-GLOSSARY#def_case_mapping">case mapped</a> to lowercase.</li>
     <li>Within <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>:
       <ul>
         <li>Characters
@@ -578,7 +581,7 @@
         <tr id="cp-uppercase-a">
           <td><code class="codepoint">U+0041</code></td>
           <td><code title="latin capital letter A">A</code></td>
-          <td>Latin capital letter E</td>
+          <td>Latin capital letter A</td>
         </tr>
         <tr id="cp-uppercase-f">
           <td><code class="codepoint">U+0046</code></td>
@@ -594,6 +597,16 @@
           <td><code class="codepoint">U+005F</code></td>
           <td><code title="underscore">_</code></td>
           <td>Underscore</td>
+        </tr>
+        <tr id="cp-lowercase-a">
+          <td><code class="codepoint">U+0061</code></td>
+          <td><code title="latin small letter A">a</code></td>
+          <td>Latin small letter A</td>
+        </tr>
+        <tr id="cp-lowercase-z">
+          <td><code class="codepoint">U+007A</code></td>
+          <td><code title="latin small letter Z">F</code></td>
+          <td>Latin small letter Z</td>
         </tr>
         <tr id="cp-delete">
           <td><code class="codepoint">U+007F</code></td>


### PR DESCRIPTION
… to lower case.

Fixes #58.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/59.html" title="Last updated on Dec 15, 2023, 8:09 PM UTC (e682d93)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/59/61a4bb3...e682d93.html" title="Last updated on Dec 15, 2023, 8:09 PM UTC (e682d93)">Diff</a>