### PR TITLE
Change "quoted triple" to "triple term"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -80,7 +80,7 @@
 <section id='abstract'>
   <p>N-Quads is a line-based, plain text format for encoding an <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a>.</p>
 
-  <p>RDF 1.2 N-Quads introduces <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
+  <p>RDF 1.2 N-Quads introduces <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
     as a fourth kind of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
     which can be used as the
     <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
@@ -199,27 +199,27 @@
     </pre>
   </section>
 
-  <section id="quoted-triples">
-    <h3>Quoted Triples</h3>
+  <section id="triple-terms">
+    <h3>Triple Terms</h3>
 
-    <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+    <p>A <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
       may be the <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
       <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of an
       <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>.</p>
 
-    <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
-      is represented as a <a href="#grammar-production-quotedTriple"><code>quotedTriple</code></a> with
+    <p>A <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
+      is represented as a <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> with
       <a href="#grammar-production-subject"><code>subject</code></a>,
       <a href="#grammar-production-predicate"><code>predicate</code></a>, and
       <a href="#grammar-production-object"><code>object</code></a>
       preceded by <a href="#cp-double-lt"><code>&lt;&lt;</code></a>, and
       followed by <a href="#cp-double-gt"><code>&gt;&gt;</code></a>.
-      Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
+      Note that <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
       may be nested.
      </p>
 
-    <pre id="ex-quoted-triple" class="example ntriples" data-transform="updateExample"
-         title="Quoted Triple">
+    <pre id="ex-triple-term" class="example ntriples" data-transform="updateExample"
+         title="Triple Term">
       <!--
       _:e38                                                <ex:familyName>                  "Smith" .
       << _:e38 <http://example.com/jobTitle> "Designer" >> <http://example.com/accordingTo> _:e22 .
@@ -751,15 +751,15 @@
             the literal has a datatype of <code>xsd:string</code>.
           </td>
         </tr>
-        <tr id="handle-quotedTriple">
+        <tr id="handle-tripleTerm">
           <td style="text-align:left;">
-            <a href="#grammar-production-quotedTriple" class="type quotedTriple">quotedTriple</a>
+            <a href="#grammar-production-tripleTerm" class="type tripleTerm">tripleTerm</a>
           </td>
           <td>
-            <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+            <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
           </td>
           <td>
-            The <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+            The <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
             is composed of the terms constructed from
             the <a href="#grammar-production-subject"><code>subject</code></a>,
             <a href="#grammar-production-predicate"><code>predicate</code></a>, and
@@ -975,9 +975,9 @@
       included "`:`" in N-Triples and N-Quads, but not in Turtle nor TriG.
       <a href="#grammar-production-PN_CHARS_U"><code>PN_CHARS_U</code></a> is a component
       of <a href="#grammar-production-PN_CHARS_U"><code>BLANK_NODE_LABEL</code></a>.</li>
-    <li>Adds support for <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
-        as described in <a href="#quoted-triples" class="sectionRef"></a>
-        with updates to <a href="#sec-parsing-terms" class="sectionRef"></a>.</li>
+    <li>Adds support for <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
+      as described in <a href="#triple-terms" class="sectionRef"></a>
+      with updates to <a href="#sec-parsing-terms" class="sectionRef"></a>.</li>
     <li>Separated <a href="#security"></a> from <a href="#sec-mediatype"></a>
       and updated language.</li>
     <li>Changes the `LANGTAG` terminal production to

--- a/spec/nquads-bnf.html
+++ b/spec/nquads-bnf.html
@@ -17,7 +17,7 @@
       <td>[3]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a></td>
     </tr>
     <tr id="grammar-production-predicate">
       <td>[4]</td>
@@ -29,7 +29,7 @@
       <td>[5]</td>
       <td><code>object</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a></td>
     </tr>
     <tr id="grammar-production-graphLabel">
       <td>[6]</td>
@@ -43,11 +43,11 @@
       <td>::=</td>
       <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">^^</code>' <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANG_DIR">LANG_DIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
-    <tr id="grammar-production-quotedTriple">
+    <tr id="grammar-production-tripleTerm">
       <td>[8]</td>
-      <td><code>quotedTriple</code></td>
+      <td><code>tripleTerm</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&lt;&lt;</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
+      <td>'<code class="grammar-literal">&lt;&lt;(</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">)&gt;&gt;</code>'</td>
     </tr>
     <tr id="grammar-declaration-terminals">
       <td colspan="4">

--- a/spec/nquads.bnf
+++ b/spec/nquads.bnf
@@ -1,11 +1,11 @@
 nquadsDoc         ::= statement? (EOL statement)* EOL?
 statement         ::= subject predicate object graphLabel? '.'
-subject           ::= IRIREF | BLANK_NODE_LABEL | quotedTriple
+subject           ::= IRIREF | BLANK_NODE_LABEL
 predicate         ::= IRIREF 
-object            ::= IRIREF | BLANK_NODE_LABEL | literal | quotedTriple
+object            ::= IRIREF | BLANK_NODE_LABEL | literal | tripleTerm
 graphLabel        ::= IRIREF | BLANK_NODE_LABEL
 literal           ::= STRING_LITERAL_QUOTE ('^^' IRIREF | LANG_DIR )?
-quotedTriple      ::= '<<' subject predicate object '>>'
+tripleTerm        ::= '<<(' subject predicate object ')>>'
 
 @terminals
 


### PR DESCRIPTION
Changes for N-Quads are minimal and should be non-controversial.

See https://github.com/w3c/rdf-n-triples/pull/50


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/60.html" title="Last updated on Mar 7, 2024, 10:32 AM UTC (5bbdaa6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/60/297b985...5bbdaa6.html" title="Last updated on Mar 7, 2024, 10:32 AM UTC (5bbdaa6)">Diff</a>