### PR TITLE
Fix tripleTerm delimiters and associated terminal descriptors.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -212,8 +212,8 @@
       <a href="#grammar-production-subject"><code>subject</code></a>,
       <a href="#grammar-production-predicate"><code>predicate</code></a>, and
       <a href="#grammar-production-object"><code>object</code></a>
-      preceded by <a href="#cp-double-lt"><code>&lt;&lt;</code></a>, and
-      followed by <a href="#cp-double-gt"><code>&gt;&gt;</code></a>.
+      preceded by <a href="#cp-double-lt-paren"><code>&lt;&lt;(</code></a>, and
+      followed by <a href="#cp-paren-double-gt"><code>)&gt;&gt;</code></a>.
       Note that <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
       may be nested.
      </p>
@@ -636,9 +636,12 @@
     <dl>
       <dt id="cp-space"><code title="space">space</code></dt>
       <dd><code class="codepoint">U+0020</code></dd>
-      <dt id="cp-double-lt"><code>&lt;&lt;</code></dt>
-      <dd>two concatenated less-than sign characters, each having the code point <code class="codepoint">U+003C</code></dd>
-      <dt id="cp-double-gt"><code>&gt;&gt;</code></dt>
+      <dt id="cp-double-lt-paren"><code>&lt;&lt;(</code></dt>
+      <dd>two concatenated less-than sign characters, each having the code point <code class="codepoint">U+003C</code>,
+        followed by a left parenthesis character, having the code point <code class="codepoint">U+0028</code></dd>
+      <dt id="cp-paren-double-gt"><code>)&gt;&gt;</code></dt>
+      <dd>a left parenthesis character, having the code point <code class="codepoint">U+0029</code>
+        followed by two concatenated greater-than sign characters, each having the code point <code class="codepoint">U+003E</code></dd>
       <dd>two concatenated greater-than sign characters, each having the code point <code class="codepoint">U+003E</code></dd>
       <dt id="cp-double-circumflex"><code>^^</code></dt>
       <dd>two concatenated circumflex accent characters, each having the code point <code class="codepoint">U+005E</code></dd>


### PR DESCRIPTION
Consistently use <<( and )>> rather than << and >>.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/62.html" title="Last updated on Aug 2, 2024, 4:23 PM UTC (8d83005)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/62/f346f95...8d83005.html" title="Last updated on Aug 2, 2024, 4:23 PM UTC (8d83005)">Diff</a>