### PR TITLE
Adds a link to the text version of the BNF file.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -484,6 +484,7 @@
       production is allowed new lines in literals MUST be escaped.</p>
 
     <div data-include="nquads-bnf.html"></div>
+    <p>A text version of this grammar is available <a href="nquads.bnf">here</a>.</p>
   </section>
 
   <section>


### PR DESCRIPTION
This makes it more convenient for people to access the EBNF without having to scrape the HTML.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/63.html" title="Last updated on Sep 18, 2024, 7:40 PM UTC (4156d52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/63/238e28e...4156d52.html" title="Last updated on Sep 18, 2024, 7:40 PM UTC (4156d52)">Diff</a>