### PR TITLE
General cleanup

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -970,7 +970,7 @@
     <dt>Required parameters:</dt>
     <dd>None</dd>
     <dt>Optional parameters:</dt>
-    <dd><code>version</code> — this parameter is required when using RDF 1.2-specific features.
+    <dd><code>version</code> — this parameter is optional but SHOULD be present when using RDF 1.2-specific features.
       If present, acceptable values of <code>version</code> are
       defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].</dd>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -99,7 +99,6 @@
   <p>RDF 1.2 N-Quads introduces <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
     as a fourth kind of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
     which can be used as the
-    <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
     <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of another
     <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>,
     making it possible to make statements about other statements.

--- a/spec/index.html
+++ b/spec/index.html
@@ -129,7 +129,9 @@
     [[RDF12-CONCEPTS]].
   </p>
 
-  <p>As with N-Triples, an <a>N-Quads document</a> contains no parsing directives.</p>
+  <p>As with N-Triples, an <a>N-Quads document</a> can contain a single kind of parsing directive
+    for announcing the RDF version of the content.
+    See <a href="#sec-version" class="sectionRef"></a>.</p>
 
   <p>N-Quads statements are a sequence of RDF terms representing the
     <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>,
@@ -190,12 +192,13 @@
       <a data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</a>,
       <a data-cite="RDF12-CONCEPTS#dfn-object">object</a>) terms
       forming an <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>
-      and an optional
+      an optional
       <a data-cite="RDF12-CONCEPTS#dfn-graph-name">graph name</a>
       (a <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a>
       or <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a>) labeling what
       <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graph</a>
-      in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to.
+      in a <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">dataset</a> the triple belongs to,
+      and terminated by <a href="#cp-full-stop"><code title="full stop">.</code></a>.
       White space (<a href="#cp-space"><code title="space">spaces</code></a>, and/or <a href="#cp-tab"><code title="horizontal tab">tabs</code></a>) may surround terms,
       except where significant as noted in the <a href="#n-quads-grammar">grammar</a>.</p>
 
@@ -219,12 +222,28 @@
 
     <p>The N-Quads language has evolved since its origin, and RDF 1.2
       adds new syntax.
-      RDF 1.2 N-Quads introduces an optional `version` <a href="#sec-mediaReg">Media Type parameter</a>.
-      When serializing N-Triple with new features such as
+      RDF 1.2 N-Quads introduces the
+      <a href="#grammar-production-versionDirective"><code>VERSION</code></a> directive
+      along with an optional `version` <a href="#sec-mediaReg">Media Type parameter</a>.
+      When serializing N-Quads with new features such as
       <a data-cite="RDF12-CONCEPTS#dfn-base-direction">initial text direction</a>
       or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>,
+      authors can announce the use of the new syntax forms using these directives, or
       servers can use the `version` <a href="#sec-mediaReg">Media Type parameter</a>.
     </p>
+
+    <p class="issue atrisk" data-number="76"></p>
+
+    <p>As with with N-Triples, the version declaration is case-sensitive.</p>
+
+    <pre id="ex-sparql-version-decl"
+         class="example n-quads" data-transform="updateExample"
+         title="Version announcement">
+      <!--
+      VERSION "1.2"
+      <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> <http://example.org/#graph> .
+      -->
+    </pre>
 
     <p>When providing content over HTTP, servers can announce the version
       using the optional `version` <a href="#sec-mediaReg">Media Type parameter</a>:</p>
@@ -233,7 +252,7 @@
          class="example http" data-transform="updateExample"
          title="HTTP version announcement">
       <!--
-      GET /document.ttl HTTP/1.1
+      GET /document.nq HTTP/1.1
       Host: example.com
       Accept: application/n-quads; version=1.2
       -->
@@ -407,6 +426,8 @@
       <code>object</code>,
       and <code>graphLabel</code>,
       any of which MUST be a single <a href="#cp-space"><code title="space">space</code></a>.</li>
+     <li>A Canonical N-Quads document MUST NOT include a
+      <a href="#grammar-production-versionDirective"><code>VERSION</code></a> announcement directive.</li>
     <li id="c14n-dt-tests" data-tests="c14n/index.html#literal_with_string_dt">
       <a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> with the
       datatype <code>http://www.w3.org/2001/XMLSchema#string</code>
@@ -572,6 +593,12 @@
     <p>Escape sequence rules are the same as N-Triples [[RDF12-N-TRIPLES]] and Turtle [[RDF12-TURTLE]].
       However, as only the <a href="#grammar-production-STRING_LITERAL_QUOTE"><code>STRING_LITERAL_QUOTE</code></a>
       production is allowed new lines in literals MUST be escaped.</p>
+
+    <p>
+      The '<code class="grammar-literal">VERSION</code>' terminal is in single quotes
+      to indicate that it is case-sensitive.
+    </p>
+    <p class="issue atrisk" data-number="76"></p>
 
     <div data-include="nquads-bnf.html"></div>
     <p>A text version of this grammar is available <a href="nquads.bnf">here</a>.</p>
@@ -754,8 +781,10 @@
       The RDF version used for parsing the document into <a data-cite="RDF12-CONCEPTS#dfn-quad">Quads</a>.
       If specified as part of a <a href="#sec-mediaReg">Media Type</a>, the default value for |curVersion| is taken from the `version` parameter.
       Acceptable values for `version` are defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].
-      Parser behavior for version values is undefined and MAY be used
-      to signal errors or warnings.
+      The version announcement is only a hint;
+      this specification does not mandate any parser behavior based on |curVersion|,
+      but a parser MAY signal an error or a warning
+      when it encounters a feature that does not match the value of |curVersion|.
     </li>
   </ul>
 
@@ -769,6 +798,16 @@
         <tr><th>production</th><th>type</th><th>procedure</th></tr>
       </thead>
       <tbody>
+        <tr id="handle-versionSpecifier">
+          <td style="text-align:left;">
+            <a class="type literal" href="#grammar-production-versionSpecifier">versionSpecifier</a>
+          </td>
+          <td><a data-cite="RDF12-CONCEPTS#dfn-literal">literal</a></td>
+          <td>The |curVersion| is taken from a literal
+            using the matched <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a>
+            lexical form and `xsd:string` datatype.
+          </td>
+        </tr>
         <tr id="handle-BLANK_NODE_LABEL">
           <td style="text-align:left;">
             <a href="#grammar-production-BLANK_NODE_LABEL" class="type bNode">BLANK_NODE_LABEL</a>

--- a/spec/nquads-bnf.html
+++ b/spec/nquads-bnf.html
@@ -1,4 +1,4 @@
-<!-- Generated with ebnf version 2.3.4. See https://github.com/dryruby/ebnf. -->
+<!-- Generated with ebnf version 2.6.0. See https://github.com/dryruby/ebnf. -->
 <table class="grammar">
   <tbody id="grammar-productions" class="ebnf">
     <tr id="grammar-production-nquadsDoc">
@@ -11,40 +11,64 @@
       <td>[2]</td>
       <td><code>statement</code></td>
       <td>::=</td>
+      <td><a href="#grammar-production-directive">directive</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-quad">quad</a> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code></td>
+    </tr>
+    <tr id="grammar-production-directive">
+      <td>[3]</td>
+      <td><code>directive</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-versionDirective">versionDirective</a></td>
+    </tr>
+    <tr id="grammar-production-versionDirective">
+      <td>[4]</td>
+      <td><code>versionDirective</code></td>
+      <td>::=</td>
+      <td>'<code class="grammar-literal">VERSION</code>' <a href="#grammar-production-versionSpecifier">versionSpecifier</a></td>
+    </tr>
+    <tr id="grammar-production-versionSpecifier">
+      <td>[5]</td>
+      <td><code>versionSpecifier</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a></td>
+    </tr>
+    <tr id="grammar-production-quad">
+      <td>[6]</td>
+      <td><code>quad</code></td>
+      <td>::=</td>
       <td><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> <a href="#grammar-production-graphLabel">graphLabel</a><code class="grammar-opt">?</code> '<code class="grammar-literal">.</code>'</td>
     </tr>
     <tr id="grammar-production-subject">
-      <td>[3]</td>
+      <td>[7]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a></td>
     </tr>
     <tr id="grammar-production-predicate">
-      <td>[4]</td>
+      <td>[8]</td>
       <td><code>predicate</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-IRIREF">IRIREF</a></td>
     </tr>
     <tr id="grammar-production-object">
-      <td>[5]</td>
+      <td>[9]</td>
       <td><code>object</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a></td>
     </tr>
     <tr id="grammar-production-graphLabel">
-      <td>[6]</td>
+      <td>[10]</td>
       <td><code>graphLabel</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a></td>
     </tr>
     <tr id="grammar-production-literal">
-      <td>[7]</td>
+      <td>[11]</td>
       <td><code>literal</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">^^</code>' <a href="#grammar-production-IRIREF">IRIREF</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <a href="#grammar-production-LANG_DIR">LANG_DIR</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-tripleTerm">
-      <td>[8]</td>
+      <td>[12]</td>
       <td><code>tripleTerm</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&lt;&lt;(</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">)&gt;&gt;</code>'</td>
@@ -55,43 +79,43 @@
       </td>
     </tr>
     <tr id="grammar-production-IRIREF">
-      <td>[10]</td>
+      <td>[14]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&gt;</code>'</td>
     </tr>
     <tr id="grammar-production-BLANK_NODE_LABEL">
-      <td>[11]</td>
+      <td>[15]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">_:</code>' <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANG_DIR">
-      <td>[12]</td>
+      <td>[16]</td>
       <td><code>LANG_DIR</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">@</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">-</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">--</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
-      <td>[13]</td>
+      <td>[17]</td>
       <td><code>STRING_LITERAL_QUOTE</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="dquote">#x22</abbr></code><code class="grammar-char-escape"><abbr title="backslash">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;</code>'</td>
     </tr>
     <tr id="grammar-production-UCHAR">
-      <td>[14]</td>
+      <td>[18]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
       <td><code class="grammar-paren">(</code>'<code class="grammar-literal">\u</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">\U</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
-      <td>[15]</td>
+      <td>[19]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf\&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
-      <td>[16]</td>
+      <td>[20]</td>
       <td><code>PN_CHARS_BASE</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">A-Z</code><code class="grammar-brac">]</code></td>
@@ -162,25 +186,25 @@
       <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+10000">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+EFFFF">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_U">
-      <td>[17]</td>
+      <td>[21]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">_</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
-      <td>[18]</td>
+      <td>[22]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>'  <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
+      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-HEX">
-      <td>[19]</td>
+      <td>[23]</td>
       <td><code>HEX</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">A-F</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-f</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-EOL">
-      <td>[20]</td>
+      <td>[24]</td>
       <td><code>EOL</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>

--- a/spec/nquads.bnf
+++ b/spec/nquads.bnf
@@ -1,5 +1,9 @@
 nquadsDoc         ::= statement? (EOL statement)* EOL?
-statement         ::= subject predicate object graphLabel? '.'
+statement         ::= directive | quad '.'
+directive         ::= versionDirective
+versionDirective  ::= 'VERSION' versionSpecifier
+versionSpecifier  ::= STRING_LITERAL_QUOTE
+quad              ::= subject predicate object graphLabel? '.'
 subject           ::= IRIREF | BLANK_NODE_LABEL
 predicate         ::= IRIREF 
 object            ::= IRIREF | BLANK_NODE_LABEL | literal | tripleTerm


### PR DESCRIPTION
* No triple terms in subject position. Fixes #66 (although in a different location).
* Make version media-type parameter optional with SHOULD. Fixes #70.
* Synchronize VERSION grammar affecting other areas based on N-Triples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/77.html" title="Last updated on Jun 30, 2025, 8:47 PM UTC (c57c348)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/77/ede8274...c57c348.html" title="Last updated on Jun 30, 2025, 8:47 PM UTC (c57c348)">Diff</a>