### PR TITLE
Section id "canonical-nquads"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -424,7 +424,7 @@
   </section>
 </section>
 
-<section id="canonical-quads">
+<section id="canonical-nquads">
   <h2>A Canonical form of N-Quads</h2>
 
   <p>This section defines a canonical form of N-Quads which has
@@ -544,7 +544,7 @@
 
   <p>A conforming <dfn>Canonical N-Quads document</dfn> is an 
     <a>N-Quads document</a> that follows the 
-    <a href="#canonical-quads">additional constraints</a> of Canonical N-Quads.</p>
+    <a href="#canonical-nquads">additional constraints</a> of Canonical N-Quads.</p>
 
   <p>A conforming <dfn>N-Quads parser</dfn> is a system capable of
     reading <a>N-Quads documents</a> on behalf of an application.
@@ -1154,7 +1154,7 @@
 
   <ul>
     <li>N-Quads is now described as an extension of N-Triples [[RDF12-N-TRIPLES]].</li>
-    <li>Add <a href="#canonical-quads" class="sectionRef"></a> to define the canonical form of N-Quads.</li>
+    <li>Add <a href="#canonical-nquads" class="sectionRef"></a> to define the canonical form of N-Quads.</li>
     <li>Better align the use of white space and comments with [[RDF12-TURTLE]].</li>
     <li>Removed language about white space use between terminals that would otherwise
       be (mis-)recognized, is this can't happen in N-Triples.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -425,6 +425,7 @@
 </section>
 
 <section id="canonical-nquads">
+  <span id="canonical-quads"><!--legacy--></span>
   <h2>A Canonical form of N-Quads</h2>
 
   <p>This section defines a canonical form of N-Quads which has


### PR DESCRIPTION
The section in N-Quads has an anchor of "canonical-quads" but the equivalent section in N-triples is "canonical-ntriples".

This PR changes N-Quads to have a section id of "canonical-nquads".

While this is minor, I'm moving between the documents at the moment and this difference stands out.
Because it is late in the document cycle, there is a legacy anchor.