### PR TITLE
Rewrite RDF Blank Nodes section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -408,10 +408,6 @@
       is not permitted as the last character.
     </p>
 
-    <p class="note">
-      This paragraph is explanatory; the normative definition is the grammar production
-      <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>.
-    </p>
 
     <p>
       A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique

--- a/spec/index.html
+++ b/spec/index.html
@@ -385,43 +385,49 @@
     </p>
   </section>
 
-  <section id="BNodes">
-    <h3>RDF Blank Nodes</h3>
-    <p>
-      As in N-Triples,
-      <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> are expressed as <a href="#cp-underscore-colon"><code>_:</code></a>
-      followed by a blank node label which is a series of name characters.
-      The characters in the label are built upon <a href="#grammar-production-PN_CHARS_BASE"><code>PN_CHARS_BASE</code></a>,
-      liberalized as follows:
-    </p>
-    <ul>
-      <li>The characters <a href="#cp-underscore"><code title="underscore">_</code></a> and
-        the digit characters <a href="#cp-zero"><code title="digit zero">0</code></a>–<a href="#cp-nine"><code title="digit nine">9</code></a>
-        may appear anywhere in a blank node label.</li>
-      <li>The character <a href="#cp-full-stop"><code title="full stop">.</code></a> may appear anywhere except the first or last character.</li>
-      <li>The characters
-        <a href="#cp-hyphen"><code title="hyphen">-</code></a>,
-        <a href="#cp-middle-dot"><code title="middle dot">·</code></a>,
-        <a href="#cp-undertie"><code title="undertie">&#x203F;</code></a>,
-        <a href="#cp-character-tie"><code title="character tie">&#x2040;</code></a>,
-        and
-        the combining diacritical marks (<code class="codepoint">U+0300</code>
-                                      to <code class="codepoint">U+036F</code>)
-        are permitted anywhere except the first character.</li>
-    </ul>
-    <p>
-      A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> in a document.
-      Repeated use of the same <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> identifies the same blank node.
-    </p>
+<section id="BNodes">
+  <h3>RDF Blank Nodes</h3>
+  <p>
+    As in N-Triples,
+    <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> are expressed as
+    <a href="#cp-underscore-colon"><code>_:</code></a>
+    followed by a blank node label matching the
+    <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>
+    production.
+  </p>
 
-    <pre id="ex-bnodes" class="example nquads" data-transform="updateExample"
-         title="Blank nodes in N-Quads">
-      <!--
-      _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
-      _:bob   <http://xmlns.com/foaf/0.1/knows> _:alice .
-      -->
-    </pre>
-  </section>
+  <p>
+    Informally, the first character after
+    <a href="#cp-underscore-colon"><code>_:</code></a>
+    is either a character matched by
+    <a href="#grammar-production-PN_CHARS_U"><code>PN_CHARS_U</code></a>
+    or a digit. Any following characters, if present, are matched by
+    <a href="#grammar-production-PN_CHARS"><code>PN_CHARS</code></a>
+    or by <a href="#cp-full-stop"><code title="full stop">.</code></a>,
+    except that <a href="#cp-full-stop"><code title="full stop">.</code></a>
+    is not permitted as the last character.
+  </p>
+
+  <p class="note">
+    This paragraph is explanatory; the normative definition is the grammar production
+    <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>.
+  </p>
+
+  <p>
+    A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique
+    <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> in a document.
+    Repeated use of the same
+    <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a>
+    identifies the same blank node.
+  </p>
+
+  <pre id="ex-bnodes" class="example nquads" data-transform="updateExample"
+       title="Blank nodes in N-Quads">
+    <!--
+    _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
+    _:bob   <http://xmlns.com/foaf/0.1/knows> _:alice .
+    -->
+  </pre>
 </section>
 
 <section id="canonical-nquads">

--- a/spec/index.html
+++ b/spec/index.html
@@ -385,49 +385,50 @@
     </p>
   </section>
 
-<section id="BNodes">
-  <h3>RDF Blank Nodes</h3>
-  <p>
-    As in N-Triples,
-    <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> are expressed as
-    <a href="#cp-underscore-colon"><code>_:</code></a>
-    followed by a blank node label matching the
-    <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>
-    production.
-  </p>
+  <section id="BNodes">
+    <h3>RDF Blank Nodes</h3>
+    <p>
+      As in N-Triples,
+      <a data-cite="RDF12-CONCEPTS#dfn-blank-node">RDF blank nodes</a> are expressed as
+      <a href="#cp-underscore-colon"><code>_:</code></a>
+      followed by a blank node label matching the
+      <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>
+      production.
+    </p>
 
-  <p>
-    Informally, the first character after
-    <a href="#cp-underscore-colon"><code>_:</code></a>
-    is either a character matched by
-    <a href="#grammar-production-PN_CHARS_U"><code>PN_CHARS_U</code></a>
-    or a digit. Any following characters, if present, are matched by
-    <a href="#grammar-production-PN_CHARS"><code>PN_CHARS</code></a>
-    or by <a href="#cp-full-stop"><code title="full stop">.</code></a>,
-    except that <a href="#cp-full-stop"><code title="full stop">.</code></a>
-    is not permitted as the last character.
-  </p>
+    <p>
+      Informally, the first character after
+      <a href="#cp-underscore-colon"><code>_:</code></a>
+      is either a character matched by
+      <a href="#grammar-production-PN_CHARS_U"><code>PN_CHARS_U</code></a>
+      or a digit. Any following characters, if present, are matched by
+      <a href="#grammar-production-PN_CHARS"><code>PN_CHARS</code></a>
+      or by <a href="#cp-full-stop"><code title="full stop">.</code></a>,
+      except that <a href="#cp-full-stop"><code title="full stop">.</code></a>
+      is not permitted as the last character.
+    </p>
 
-  <p class="note">
-    This paragraph is explanatory; the normative definition is the grammar production
-    <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>.
-  </p>
+    <p class="note">
+      This paragraph is explanatory; the normative definition is the grammar production
+      <a href="#grammar-production-BLANK_NODE_LABEL"><code>BLANK_NODE_LABEL</code></a>.
+    </p>
 
-  <p>
-    A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique
-    <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> in a document.
-    Repeated use of the same
-    <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a>
-    identifies the same blank node.
-  </p>
+    <p>
+      A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique
+      <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> in a document.
+      Repeated use of the same
+      <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a>
+      identifies the same blank node.
+    </p>
 
-  <pre id="ex-bnodes" class="example nquads" data-transform="updateExample"
-       title="Blank nodes in N-Quads">
+    <pre id="ex-bnodes" class="example nquads" data-transform="updateExample"
+         title="Blank nodes in N-Quads">
     <!--
     _:alice <http://xmlns.com/foaf/0.1/knows> _:bob .
     _:bob   <http://xmlns.com/foaf/0.1/knows> _:alice .
     -->
-  </pre>
+    </pre>
+  </section>
 </section>
 
 <section id="canonical-nquads">


### PR DESCRIPTION
see https://github.com/w3c/rdf-n-quads/issues/96

Align explanatory prose for blank node labels with the normative BLANK_NODE_LABEL grammar, without changing accepted syntax.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/98.html" title="Last updated on Apr 23, 2026, 7:54 AM UTC (a1b055a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/98/b1c7002...a1b055a.html" title="Last updated on Apr 23, 2026, 7:54 AM UTC (a1b055a)">Diff</a>