### PR TITLE
Add optional profile media type parameter to N-Quads

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1079,9 +1079,24 @@
     <dt>Required parameters:</dt>
     <dd>None</dd>
     <dt>Optional parameters:</dt>
-    <dd><code>version</code> — this parameter is optional but SHOULD be present when using RDF 1.2-specific features.
-      If present, acceptable values of <code>version</code> are
-      defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].</dd>
+    <dd>
+      <dl>
+        <dt><code>version</code></dt>
+        <dd>This parameter is optional.
+          This parameter is optional but SHOULD be present when using RDF 1.2-specific features.
+          If present, acceptable values of <code>version</code> are
+          defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].
+        </dd>
+        <dt><code>profile</code></dt>
+        <dd>
+          This parameter is optional and is used to include additional information.
+          It does not change the semantics of the resource representation when processed
+          without knowledge of the profile.
+          The value of a profile parameter is a non-empty list of space-separated URIs.
+          For more information and background, please refer to [[RFC6906]].
+        </dd>
+      </dl>
+    </dd>
 
     <dt>Encoding considerations:</dt>
     <dd>The syntax of N-Quads is expressed over code points in Unicode [[!UNICODE]].
@@ -1120,6 +1135,51 @@
     <dt>Author(s):</dt>
     <dd>The N-Quads specification is the product of the RDF &amp; SPARQL WG. The W3C reserves change control over this specifications.</dd>
   </dl>
+
+  <div id="about-profile">
+    <div class="note">
+      <p>
+        The `profile` parameter may be used by clients to express their preferences
+        in the content negotiation process and by a server to indicate
+        additional information about the response.
+      </p>
+      <p>
+        If the `profile` parameter is given by a client, a server should
+        return a document that honors all the profiles in the list 
+        that are recognized by the server.
+        A server should not respond with an error solely based upon the profile value.
+      </p> 
+      <p>
+        If the `profile` parameter is given by a server, a client may choose to ignore it.
+      </p>
+    </div>
+    <div class="note">
+      <p>It is recommended that profile URIs be dereferenceable
+        and provide useful documentation at that URI.
+      </p>
+    </div>
+
+    <div class="note">
+      <p>
+        When used as a 
+        <a href="https://tools.ietf.org/html/rfc4288#section-4.3">media type parameter</a>
+        [[RFC4288]] in an
+        <a href="https://httpwg.org/specs/rfc7231.html#header.content-type">HTTP Content-Type header</a>
+        or an
+        <a href="https://httpwg.org/specs/rfc7231.html#header.accept">HTTP Accept header</a> 
+        [[RFC7231]] the value of the `profile` parameter will need to be enclosed in quotes (ASCII `"`)
+        if it contains special characters such as white space, including any space
+        used to separate multiple profile URIs.
+      </p>
+      <p>
+        It is important to note that the value of the `profile` parameter
+        contains one or more URIs and not IRIs. It might therefore be necessary
+        to convert between IRIs and URIs, as specified in
+        <a href="https://tools.ietf.org/html/rfc3986#section-5.1">section 3 Relationship between IRIs and URIs</a>
+        of [[RFC3987]].
+      </p>
+    </div>
+  </div>
 </section>
 
 <section id="section-ack" class="informative">
@@ -1191,6 +1251,9 @@
     <li>Clarify that 
       <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">Unicode surrogates</a> 
       are not legal in N-Quads documents, nor as the value of a Unicode escape sequence.</li>
+    <li>Added the optional <code>profile</code> media type parameter
+      to allow clients and servers to convey additional profile information
+      for N-Quads representations without changing their semantics.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1083,7 +1083,6 @@
       <dl>
         <dt><code>version</code></dt>
         <dd>This parameter is optional.
-          This parameter is optional but SHOULD be present when using RDF 1.2-specific features.
           If present, acceptable values of <code>version</code> are
           defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].
         </dd>


### PR DESCRIPTION
see https://github.com/w3c/rdf-n-quads/issues/88

This PR adds the optional `profile` media type parameter to the N-Quads media type registration. The change aligns the specification with the possibility of conveying additional profile information for N-Quads representations, for example, during content negotiation or in response metadata, without changing the semantics of the representation itself. It also adds explanatory text describing the intended use of the parameter, its behavior for clients and servers, and practical considerations such as quoted values in HTTP headers and the use of dereferenceable profile URIs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/101.html" title="Last updated on May 22, 2026, 7:54 PM UTC (812a36a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/101/7abd155...812a36a.html" title="Last updated on May 22, 2026, 7:54 PM UTC (812a36a)">Diff</a>