### PR TITLE
reorganize content about backward compatibility

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -188,14 +188,7 @@
   <p>
     This specification extends the original N-Quads syntax, as defined in [[[N-QUADS]]] [[N-QUADS]],
     to support the new features introduced by [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]].
-    This extension is fully backward compatible:
-    any document complying with the old version complies with the new version, and parses to the same graph.
-    Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
-    (with the exception of the `VERSION` directive; see <a href="#sec-version"></a>).
-    Finally, none of the new syntactic constructs are valid in the old syntax.
-    This means that any N-Quads document using RDF 1.2 features does not
-    comply with the previous version of this specification and cannot be
-    interpreted as a different graph under it.
+    This extension is fully backward compatible.
   </p>
 
 </section>
@@ -1216,6 +1209,20 @@
 <section class="appendix informative" id="changes-12">
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
+  <p>
+    This specification extends the original N-Quads syntax, as defined in [[[N-QUADS]]] [[N-QUADS]],
+    to support the new features introduced by [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]].
+    This extension is fully backward compatible:
+    any document complying with the old version complies with the new version, and parses to the same graph.
+    Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
+    (with the exception of the `VERSION` directive; see <a href="#sec-version"></a>).
+    Finally, none of the new syntactic constructs are valid in the old syntax.
+    This means that any N-Quads document using RDF 1.2 features does not
+    comply with the previous version of this specification and cannot be
+    interpreted as a different graph under it.
+  </p>
+
+  <p>More specifically, the following changes have been made:</p>
   <ul>
     <li>N-Quads is now described as an extension of N-Triples [[RDF12-N-TRIPLES]].</li>
     <li>Add <a href="#canonical-nquads" class="sectionRef"></a> to define the canonical form of N-Quads.</li>


### PR DESCRIPTION
following the same rationale as [w3c/n-triples#105](https://github.com/w3c/rdf-n-triples/pull/105)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/102.html" title="Last updated on May 29, 2026, 12:12 PM UTC (7ccc00d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/102/0bc4c17...7ccc00d.html" title="Last updated on May 29, 2026, 12:12 PM UTC (7ccc00d)">Diff</a>