### PR TITLE
Remove out-of-date aside

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -326,7 +326,7 @@
       As in N-Triples, <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may be written only as <a data-cite="RFC3986#section-5">resolved</a> IRIs.
       IRIs are preceded by <a href="#cp-less-than"><code title="less-than sign">&lt;</code></a> and
       followed by <a href="#cp-greater-than"><code title="greater-than sign">&gt;</code></a>,
-      and may contain <a data-cite="RDF12-TURTLE#dfn-numeric-escape-sequence">numeric escape sequences</a> (described below).
+      and may contain <a data-cite="RDF12-TURTLE#dfn-numeric-escape-sequence">numeric escape sequences</a>.
       For example <code>&lt;http://example.org/#green-goblin&gt;</code>.
     </p>
   </section>


### PR DESCRIPTION
The link goes to Turtle, not later in this document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/106.html" title="Last updated on Jun 12, 2026, 8:45 AM UTC (a0767c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/106/e340900...a0767c2.html" title="Last updated on Jun 12, 2026, 8:45 AM UTC (a0767c2)">Diff</a>