### PR TITLE
Use ReSpec "data" table style and drop unused CSS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -60,14 +60,6 @@
 
   <style>
     /* Style Turtle script blocks to be visible */
-    pre.example script { display:block;  overflow-x: auto; }
-    .separated { border-collapse:collapse; }
-    .separated thead tr th { border:1px solid black; padding: .2em; min-width: 10vw }
-    .separated tbody tr td { border:1px solid black; text-align: center; min-width: 10vw }
-    .separated tbody tr td.r { text-align: right; padding: .5em; }
-    .separated tbody tr td:first-child,
-    .separated tbody tr td:last-child {text-align: left; padding: .5em; }
-    .separated.last-center tbody tr td:last-child {text-align: center; padding: .5em; }
     .grammar td {
       font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
       font-size: .9em;
@@ -80,38 +72,11 @@
     .grammar-plus,
     .grammar-star,
     .grammar-brac { color: gray;}
-    .grammar_comment { color: #A52A2A; font-style: italic; }
     #grammar-declaration-terminals h3 {
       margin-top: 1em;
     }
-    .hl-bold { font-weight: bold; color: #0a3; }
     code { color: #ff4500; }  /* Old W3C Style */
     var { color: #ff4500; }
-    abbr[title] {text-decoration: none;}
-    @media (max-width: 850px) {
-        table th, table td { font-size: 12px; padding: 3px 4px;}
-        table.ex th, table.ex td {overflow-x: scroll; max-width: 42vw !important;}
-    }
-    @media (max-width: 767px) {
-      table { word-break: break-all; }
-      .separated thead tr th { border:1px solid black; padding: .2em; min-width: 10vw }
-      .separated thead tr th:nth-child(2) { word-break: break-all; }
-      .separated tbody tr td:nth-child(2) {padding: 3px 2px;}
-      .separated tbody tr td:nth-child(3) {padding: 3px 2px;}
-      .separated tbody tr td { border:1px solid black; text-align: center; min-width: 10vw }
-      table { word-break: normal; overflow-wrap: anywhere; }
-      table.ex, .ex th, .ex td { border: none; padding: 0; }
-      table.ex { font-size: 1.4vw; }
-      .separated tbody tr td:first-child, .separated tbody tr th:first-child {max-width: 220px; overflow-wrap: anywhere;}
-    }
-    .ex th { text-align: center; }
-
-    table.cp-definitions { border-collapse:collapse; }
-
-    table.cp-definitions,
-    table.cp-definitions th,
-    table.cp-definitions td { border:0px solid black; padding:0.2em; }
-    table.cp-definitions td:nth-child(2) { text-align: center; }
   </style>
 </head>
 <body>
@@ -648,7 +613,7 @@
       table describes specific characters and sequences used throughout this document.</p>
 
     <!-- Selected unicode character descriptions, taken from https://en.wikipedia.org/wiki/List_of_Unicode_characters -->
-    <table class="cp-definitions">
+    <table class="data">
       <thead>
         <tr><th>Code</th><th>Glyph</th><th>Description</th></tr>
       </thead>
@@ -830,7 +795,7 @@
     <p>This table maps productions and lexical tokens to <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>
       or components of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>
       listed in <a href="#sec-parsing" class="sectionRef"></a>:</p>
-    <table id="tab-term-constructors" class="separated">
+    <table id="tab-term-constructors" class="data">
       <thead>
         <tr><th>production</th><th>type</th><th>procedure</th></tr>
       </thead>


### PR DESCRIPTION
Port of https://github.com/w3c/rdf-n-triples/pull/106
Screenshot there


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/pull/107.html" title="Last updated on Jul 23, 2026, 4:37 PM UTC (0e1ad5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-n-quads/107/3575756...0e1ad5f.html" title="Last updated on Jul 23, 2026, 4:37 PM UTC (0e1ad5f)">Diff</a>